### PR TITLE
HOCS-1057 Match ACP global settings

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ audit.queue.dlq=seda://${audit.queue.dlq.name}
 hocs.info-service=http://localhost:8085
 hocs.basicauth=UNSET
 
-audit.queue.maximumRedeliveries=5
+audit.queue.maximumRedeliveries=10
 audit.queue.redeliveryDelay=10000
 audit.queue.backOffMultiplier=5
 


### PR DESCRIPTION
ACP by default sets maxReceiveCount to 10, but our app sets it to 5.
This commit changes it to match ACP, so we don't keep overwriting each other's configs.