### PR TITLE
Update exported timestamp to show local London time + Order allocations timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker-compose down
 ### Running in an IDE
 
 If you are using an IDE, such as IntelliJ, this audit service can be started by running the ```HocsAuditApplication``` main class. 
-The service can then be accessed at ```http://localhost:8088```.
+The service can then be accessed at ```http://localhost:8087```.
 
 ### Building and running without an IDE
 

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/application/ZonedDateTimeConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/application/ZonedDateTimeConverter.java
@@ -13,7 +13,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class ZonedDateTimeConverter {
 
-    private static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    private static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS";
 
     private DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT);
     private ZoneId specifiedTimeZoneId = ZoneId.of("Europe/London");

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/application/ZonedDateTimeConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/application/ZonedDateTimeConverter.java
@@ -1,0 +1,50 @@
+package uk.gov.digital.ho.hocs.audit.application;
+
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter that for the user to pass in a local date time and to return the offset
+ * against a specified time zone.
+ */
+public class ZonedDateTimeConverter {
+
+    private static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+    private DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT);
+    private ZoneId specifiedTimeZoneId = ZoneId.of("Europe/London");
+
+    /**
+     * Constructor that allows for a user specified date format.
+     * @param outputtedDateFormat the date format to output against.
+     * @param timeZoneId the timezone to set against.
+     */
+    public ZonedDateTimeConverter(final String outputtedDateFormat, final String timeZoneId) {
+        if (StringUtils.hasText(outputtedDateFormat)) {
+            this.dateTimeFormatter = DateTimeFormatter.ofPattern(outputtedDateFormat);
+        }
+
+        if (StringUtils.hasText(timeZoneId)) {
+            this.specifiedTimeZoneId = ZoneId.of(timeZoneId);
+        }
+    }
+
+    /**
+     * A helper to return the timestamp as an offset against the specified time zone.
+     * @param localDateTime the time you want to show the offset of.
+     * @return the offsetted date time string
+     */
+    public String convert(final LocalDateTime localDateTime) {
+        final ZonedDateTime zonedDateTime =
+                localDateTime
+                        .atZone(ZoneId.systemDefault())
+                        .withZoneSameInstant(specifiedTimeZoneId);
+
+        return zonedDateTime.toLocalDateTime().format(dateTimeFormatter);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepository.java
@@ -40,7 +40,7 @@ public interface AuditRepository extends PagingAndSortingRepository<AuditData, S
     List<AuditData> findAuditDataByCaseUUIDAndTypesIn(UUID caseUUID, String[] types);
 
     @QueryHints(value = @QueryHint(name = HINT_FETCH_SIZE, value = "50"))
-    @Query(value = "SELECT a.* FROM audit_data a WHERE a.audit_timestamp BETWEEN ?1 AND ?2 AND a.type in ?3 AND a.case_type = ?4 AND a.deleted = false", nativeQuery = true)
+    @Query(value = "SELECT a.* FROM audit_data a WHERE a.audit_timestamp BETWEEN ?1 AND ?2 AND a.type in ?3 AND a.case_type = ?4 AND a.deleted = false ORDER BY a.audit_timestamp ASC", nativeQuery = true)
     Stream<AuditData> findAuditDataByDateRangeAndEvents(LocalDateTime dateFrom, LocalDateTime dateTo, String[] types, String caseType);
 
     @QueryHints(value = @QueryHint(name = HINT_FETCH_SIZE, value = "50"))

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
@@ -27,12 +27,14 @@ public class DataExportResource {
     void getDataExport(@RequestParam("fromDate") LocalDate fromDate, @RequestParam("toDate") LocalDate toDate,
                        @PathVariable("caseType") String caseType, @RequestParam("exportType") ExportType exportType,
                        @RequestParam(name = "convert", defaultValue = "false") boolean convert,
+                       @RequestParam(name = "timestampFormat", required = false) String timestampFormat,
+                       @RequestParam(name = "timeZoneId", required = false) String timeZoneId,
                        HttpServletResponse response) {
         try {
             response.setContentType("text/csv");
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
                     "attachment; filename=" + getFileName(caseType, exportType));
-            exportService.auditExport(fromDate, toDate, response.getOutputStream(), caseType, exportType, convert);
+            exportService.auditExport(fromDate, toDate, response.getOutputStream(), caseType, exportType, convert, timestampFormat, timeZoneId);
             response.setStatus(200);
         } catch (Exception ex) {
             log.error("Error exporting CSV file for case type {} and export type {} for reason {}", caseType, exportType.toString(), ex.toString());

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/ZonedDateTimeConverterTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/ZonedDateTimeConverterTest.java
@@ -1,0 +1,123 @@
+package uk.gov.digital.ho.hocs.audit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.zone.ZoneRulesException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+public class ZonedDateTimeConverterTest {
+
+    @Test
+    public void shouldShowSpecifiedFormatWhenTimestampFormatValid() {
+        ZonedDateTimeConverter zonedDateTimeConverter
+                = new ZonedDateTimeConverter("yyyy-MM-dd", null);
+
+        LocalDateTime localDateTime =
+                LocalDateTime.of(2020, 12, 12, 0, 0, 0)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime();
+
+        String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
+
+        assertThat(convertedDateTime).isNotNull();
+        assertThat(convertedDateTime).isEqualTo("2020-12-12");
+    }
+
+    @Test
+    public void shouldShowDefaultFormatWhenTimestampFormatNull() {
+        ZonedDateTimeConverter zonedDateTimeConverter
+                = new ZonedDateTimeConverter(null, null);
+
+        LocalDateTime localDateTime =
+                LocalDateTime.of(2020, 12, 12, 0, 0, 0)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+
+        String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
+
+        assertThat(convertedDateTime).isNotNull();
+        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+    }
+
+    @Test
+    public void shouldShowDefaultFormatWhenTimestampFormatEmpty() {
+        ZonedDateTimeConverter zonedDateTimeConverter
+                = new ZonedDateTimeConverter("", null);
+
+        LocalDateTime localDateTime =
+                LocalDateTime.of(2020, 12, 12, 0, 0, 0)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime();
+
+        String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
+
+        assertThat(convertedDateTime).isNotNull();
+        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTimestampFormatInvalid() {
+        new ZonedDateTimeConverter("INVALID", null);
+    }
+
+    @Test
+    public void shouldShowDefaultFormatWhenTimestampFormatValid() {
+        ZonedDateTimeConverter zonedDateTimeConverter
+                = new ZonedDateTimeConverter(null, "Europe/Rome");
+
+        LocalDateTime localDateTime =
+                LocalDateTime.of(2020, 12, 12, 0, 0, 0)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime();
+
+        String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
+
+        assertThat(convertedDateTime).isNotNull();
+        assertThat(convertedDateTime).isEqualTo("2020-12-12 01:00:00");
+    }
+
+    @Test
+    public void shouldShowSystemDefaultWhenZoneIdNull() {
+        ZonedDateTimeConverter zonedDateTimeConverter
+                = new ZonedDateTimeConverter(null, null);
+
+        LocalDateTime localDateTime =
+                LocalDateTime.of(2020, 12, 12, 0, 0, 0)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime();
+
+        String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
+
+        assertThat(convertedDateTime).isNotNull();
+        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+    }
+
+    @Test
+    public void shouldShowSystemDefaultWhenZoneIdEmpty() {
+        ZonedDateTimeConverter zonedDateTimeConverter
+                = new ZonedDateTimeConverter(null, "");
+
+        LocalDateTime localDateTime =
+                LocalDateTime.of(2020, 12, 12, 0, 0, 0)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime();
+
+        String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
+
+        assertThat(convertedDateTime).isNotNull();
+        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+    }
+
+    @Test(expected = ZoneRulesException.class)
+    public void shouldThrowExceptionIfZoneIdInvalid() {
+        new ZonedDateTimeConverter(null, "INVALID");
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/ZonedDateTimeConverterTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/ZonedDateTimeConverterTest.java
@@ -21,7 +21,7 @@ public class ZonedDateTimeConverterTest {
 
         LocalDateTime localDateTime =
                 LocalDateTime.of(2020, 12, 12, 0, 0, 0)
-                        .atZone(ZoneId.systemDefault())
+                        .atZone(ZoneId.of("GMT"))
                         .toLocalDateTime();
 
         String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
@@ -43,7 +43,7 @@ public class ZonedDateTimeConverterTest {
         String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
 
         assertThat(convertedDateTime).isNotNull();
-        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+        assertThat(convertedDateTime).isEqualTo("2020-12-12T00:00:00.000000");
     }
 
     @Test
@@ -53,13 +53,13 @@ public class ZonedDateTimeConverterTest {
 
         LocalDateTime localDateTime =
                 LocalDateTime.of(2020, 12, 12, 0, 0, 0)
-                        .atZone(ZoneId.systemDefault())
+                        .atZone(ZoneId.of("GMT"))
                         .toLocalDateTime();
 
         String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
 
         assertThat(convertedDateTime).isNotNull();
-        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+        assertThat(convertedDateTime).isEqualTo("2020-12-12T00:00:00.000000");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -74,13 +74,13 @@ public class ZonedDateTimeConverterTest {
 
         LocalDateTime localDateTime =
                 LocalDateTime.of(2020, 12, 12, 0, 0, 0)
-                        .atZone(ZoneId.systemDefault())
+                        .atZone(ZoneId.of("GMT"))
                         .toLocalDateTime();
 
         String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
 
         assertThat(convertedDateTime).isNotNull();
-        assertThat(convertedDateTime).isEqualTo("2020-12-12 01:00:00");
+        assertThat(convertedDateTime).isEqualTo("2020-12-12T01:00:00.000000");
     }
 
     @Test
@@ -90,13 +90,13 @@ public class ZonedDateTimeConverterTest {
 
         LocalDateTime localDateTime =
                 LocalDateTime.of(2020, 12, 12, 0, 0, 0)
-                        .atZone(ZoneId.systemDefault())
+                        .atZone(ZoneId.of("GMT"))
                         .toLocalDateTime();
 
         String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
 
         assertThat(convertedDateTime).isNotNull();
-        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+        assertThat(convertedDateTime).isEqualTo("2020-12-12T00:00:00.000000");
     }
 
     @Test
@@ -106,13 +106,13 @@ public class ZonedDateTimeConverterTest {
 
         LocalDateTime localDateTime =
                 LocalDateTime.of(2020, 12, 12, 0, 0, 0)
-                        .atZone(ZoneId.systemDefault())
+                        .atZone(ZoneId.of("GMT"))
                         .toLocalDateTime();
 
         String convertedDateTime = zonedDateTimeConverter.convert(localDateTime);
 
         assertThat(convertedDateTime).isNotNull();
-        assertThat(convertedDateTime).isEqualTo("2020-12-12 00:00:00");
+        assertThat(convertedDateTime).isEqualTo("2020-12-12T00:00:00.000000");
     }
 
     @Test(expected = ZoneRulesException.class)

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
@@ -1,18 +1,10 @@
 package uk.gov.digital.ho.hocs.audit.export;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,7 +15,15 @@ import uk.gov.digital.ho.hocs.audit.auditdetails.repository.AuditRepository;
 import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.*;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -95,7 +95,7 @@ public class AuditExportServiceTest {
         when(auditRepository.findLastAuditDataByDateRangeAndEvents(any(), any(), eq(ExportService.CASE_DATA_EVENTS), any())).thenReturn(getCaseDataAuditData().stream());
 
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, false, null, null);
 
         List<CSVRecord> rows = getCSVRows(outputStream.toString());
         assertThat(rows.size()).isEqualTo(3);
@@ -124,7 +124,7 @@ public class AuditExportServiceTest {
         when(auditRepository.findLastAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getCaseDataAuditData().stream());
 
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, false, null, null);
 
         String csvBody = outputStream.toString();
         Set<String> headers = getCSVHeaders(csvBody).keySet();
@@ -138,7 +138,7 @@ public class AuditExportServiceTest {
         when(auditRepository.findLastAuditDataByDateRangeAndEvents(any(), any(), eq(ExportService.CASE_DATA_EVENTS), any())).thenReturn(getCaseDataAuditData().stream());
 
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, false, null, null);
 
         verify(auditRepository, times(1)).findLastAuditDataByDateRangeAndEvents(from, to, ExportService.CASE_DATA_EVENTS, "a1");
         verify(exportDataConverter, times(0)).convertData(any());
@@ -152,7 +152,7 @@ public class AuditExportServiceTest {
         when(exportDataConverter.convertData(any())).thenAnswer(a -> a.getArguments()[0]);
 
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, true);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, true, null, null);
 
         verify(auditRepository, times(1)).findLastAuditDataByDateRangeAndEvents(from, to, ExportService.CASE_DATA_EVENTS, "a1");
         verify(exportDataConverter, times(getCaseDataAuditData().size())).convertData(any());
@@ -165,7 +165,7 @@ public class AuditExportServiceTest {
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getTopicDataAuditData().stream());
 
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.TOPICS, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.TOPICS, false, null, null);
 
         String csvBody = outputStream.toString();
         Set<String> headers = getCSVHeaders(csvBody).keySet();
@@ -176,7 +176,7 @@ public class AuditExportServiceTest {
     public void caseTopicExportShouldOnlyRequestTopicEventsAndCaseType() throws IOException {
         OutputStream outputStream = new ByteArrayOutputStream();
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getTopicDataAuditData().stream());
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.TOPICS, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.TOPICS, false, null, null);
         verify(auditRepository, times(1)).findAuditDataByDateRangeAndEvents(from, to, ExportService.TOPIC_EVENTS, "a1");
         verify(exportDataConverter, times(0)).convertData(any());
     }
@@ -191,7 +191,7 @@ public class AuditExportServiceTest {
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getCorrespondentDataAuditData().stream());
 
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CORRESPONDENTS, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CORRESPONDENTS, false, null, null);
 
         String csvBody = outputStream.toString();
         Set<String> headers = getCSVHeaders(csvBody).keySet();
@@ -202,7 +202,7 @@ public class AuditExportServiceTest {
     public void caseCorrespondentExportShouldOnlyRequestCorrespondentEventsAndCaseType() throws IOException {
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getCorrespondentDataAuditData().stream());
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CORRESPONDENTS, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CORRESPONDENTS, false, null, null);
         verify(auditRepository, times(1)).findAuditDataByDateRangeAndEvents(from, to, ExportService.CORRESPONDENT_EVENTS, "a1");
         verify(exportDataConverter, times(0)).convertData(any());
     }
@@ -212,7 +212,7 @@ public class AuditExportServiceTest {
         String[] expectedHeaders = new String[]{"timestamp", "event" ,"userId","caseUuid","stage", "allocatedTo", "deadline"};
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getAllocationDataAuditData().stream());
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.ALLOCATIONS, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.ALLOCATIONS, false, null, null);
 
         String csvBody = outputStream.toString();
         Set<String> headers = getCSVHeaders(csvBody).keySet();
@@ -223,7 +223,7 @@ public class AuditExportServiceTest {
     public void caseAllocationsExportShouldOnlyRequestCreateUpdateEventsAndCaseType() throws IOException {
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getAllocationDataAuditData().stream());
         OutputStream outputStream = new ByteArrayOutputStream();
-        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.ALLOCATIONS, false);
+        exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.ALLOCATIONS, false, null, null);
         verify(auditRepository, times(1)).findAuditDataByDateRangeAndEvents(from, to, ExportService.ALLOCATION_EVENTS, "a1");
         verify(exportDataConverter, times(0)).convertData(any());
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/DataExportResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/DataExportResourceTest.java
@@ -44,7 +44,7 @@ public class DataExportResourceTest {
         ServletOutputStream servletOutputStream = mock(ServletOutputStream.class);
         when(response.getOutputStream()).thenReturn(servletOutputStream);
 
-        dataExportResource.getDataExport(fromDate, toDate, caseType, exportType, false, response);
+        dataExportResource.getDataExport(fromDate, toDate, caseType, exportType, false, null, null, response);
 
         verify(response).setContentType("text/csv");
         verify(response).setHeader(HttpHeaders.CONTENT_DISPOSITION,
@@ -52,7 +52,7 @@ public class DataExportResourceTest {
                         LocalDate.now().toString() + ".csv");
         verify(response).setStatus(200);
         verify(response).getOutputStream();
-        verify(exportService).auditExport(fromDate, toDate, servletOutputStream, caseType, exportType, false);
+        verify(exportService).auditExport(fromDate, toDate, servletOutputStream, caseType, exportType, false, null, null);
 
         checkNoMoreInteractions();
     }
@@ -66,9 +66,9 @@ public class DataExportResourceTest {
 
         ServletOutputStream servletOutputStream = mock(ServletOutputStream.class);
         when(response.getOutputStream()).thenReturn(servletOutputStream);
-        doThrow(new IllegalArgumentException("Dummy exception")).when(exportService).auditExport(fromDate, toDate, servletOutputStream, caseType, exportType, false);
+        doThrow(new IllegalArgumentException("Dummy exception")).when(exportService).auditExport(fromDate, toDate, servletOutputStream, caseType, exportType, false, null, null);
 
-        dataExportResource.getDataExport(fromDate, toDate, caseType, exportType, false, response);
+        dataExportResource.getDataExport(fromDate, toDate, caseType, exportType, false, null, null, response);
 
         verify(response).setContentType("text/csv");
         verify(response).setHeader(HttpHeaders.CONTENT_DISPOSITION,
@@ -76,7 +76,7 @@ public class DataExportResourceTest {
                         LocalDate.now().toString() + ".csv");
         verify(response).setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         verify(response).getOutputStream();
-        verify(exportService).auditExport(fromDate, toDate, servletOutputStream, caseType, exportType, false);
+        verify(exportService).auditExport(fromDate, toDate, servletOutputStream, caseType, exportType, false, null, null);
 
         checkNoMoreInteractions();
     }


### PR DESCRIPTION
On exporting allocations (and any other exports that use the timestamp), we now change the date time to reflect what is current in the Europe/London zone id. Also, now order's by the audit_timestamp by ascending order.