### PR TITLE
HOCS-2099 MI Allocations Exception

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
@@ -229,7 +229,7 @@ public class ExportService {
                     }
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
-                } catch (IOException e) {
+                } catch (IOException | NullPointerException e) {
                     log.error("Unable to parse record for audit {} for reason {}", audit.getUuid(), e.getMessage(), value(LogEvent.EVENT, CSV_EXPORT_FAILURE));
                 }
             });


### PR DESCRIPTION
The logs in QA and PROD indicate a null pointer exception, causing the CSV processing to be blanked out completely. Including null pointer exception processing to capture the lines at fault.