### PR TITLE
HOCS-2099 MI Allocations Exception

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
@@ -165,6 +165,10 @@ public class ExportService {
                 "address3", "country", "postcode", "telephone", "email",
                 "reference", "externalKey").collect(Collectors.toList());
 
+        if (convert){
+            exportDataConverter.initialise();
+        }
+
         try (CSVPrinter printer = new CSVPrinter(outputWriter, CSVFormat.DEFAULT.withHeader(headers.toArray(new String[headers.size()])))) {
 
             Stream<AuditData> data = auditRepository.findAuditDataByDateRangeAndEvents(LocalDateTime.of(
@@ -217,6 +221,11 @@ public class ExportService {
     void allocationExport(LocalDate from, LocalDate to, OutputStreamWriter outputWriter, String caseTypeCode, boolean convert, final ZonedDateTimeConverter zonedDateTimeConverter) throws IOException {
         log.info("Exporting ALLOCATION to CSV", value(EVENT, CSV_EXPORT_START));
         List<String> headers = Stream.of("timestamp", "event", "userId", "caseUuid", "stage", "allocatedTo", "deadline").collect(Collectors.toList());
+
+        if (convert){
+            exportDataConverter.initialise();
+        }
+
         try (CSVPrinter printer = new CSVPrinter(outputWriter, CSVFormat.DEFAULT.withHeader(headers.toArray(new String[headers.size()])))) {
             Stream<AuditData> data = auditRepository.findAuditDataByDateRangeAndEvents(LocalDateTime.of(
                     from, LocalTime.MIN), LocalDateTime.of(to, LocalTime.MAX),


### PR DESCRIPTION
The logs in QA and PROD indicate a null pointer exception, causing the CSV processing to be blanked out completely.
The cause is the convert init not being processed for certain reports (correspondents and allocations).
Added the init code.
