### PR TITLE
HOCS-2095: Upgrade Camel Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         springBootVersion = '2.0.5.RELEASE'
-        camelVersion = '2.22.0'
+        camelVersion = '2.23.1'
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
As a result of a continuing error when removing a user from a team, the error revolves around Apache Camel. To rule out a potential version mismatch, this commit brings it inline with the version specified in hocs-info-service.