### PR TITLE
HOCS-2441 : MPAM entity codes replace with titles

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
@@ -106,7 +106,7 @@ public class ExportService {
                 try {
                     String[] parsedAudit = parseCaseDataAuditPayload(audit, caseDataHeaders, zonedDateTimeConverter);
                     if (convert){
-                        parsedAudit = exportDataConverter.convertData(parsedAudit);
+                        parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
@@ -157,7 +157,7 @@ public class ExportService {
                 try {
                     String[] parsedAudit = parseCaseNotesAuditPayload(audit, zonedDateTimeConverter);
                     if (convert){
-                        parsedAudit = exportDataConverter.convertData(parsedAudit);
+                        parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
@@ -215,7 +215,7 @@ public class ExportService {
                     if (filterSomuIType(audit, somuTypeDto)) {
                         String[] parsedAudit = parseCaseDataSomuAuditPayload(audit, somuHeaders, zonedDateTimeConverter);
                         if (convert) {
-                            parsedAudit = exportDataConverter.convertData(parsedAudit);
+                            parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                         }
                         printer.printRecord(parsedAudit);
                         outputWriter.flush();
@@ -317,7 +317,7 @@ public class ExportService {
                 try {
                     String[] parsedAudit = parseCorrespondentAuditPayload(audit, zonedDateTimeConverter);
                     if (convert){
-                        parsedAudit = exportDataConverter.convertData(parsedAudit);
+                        parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
@@ -376,7 +376,7 @@ public class ExportService {
                 try {
                     String[] parsedAudit = parseAllocationAuditPayload(audit, zonedDateTimeConverter);
                     if (convert){
-                        parsedAudit = exportDataConverter.convertData(parsedAudit);
+                        parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClient.java
@@ -151,5 +151,12 @@ public class InfoClient {
         return null;
     }
 
+    @Cacheable(value = "getEntitiesForList", unless = "#result == null")
+    public Set<EntityDto> getEntitiesForList(String simpleName) {
+        Set<EntityDto> entities = restHelper.get(serviceBaseURL, String.format("/entity/list/%s", simpleName), new ParameterizedTypeReference<Set<EntityDto>>() {
+        });
+        log.info("Got {} entities for list", entities.size(), value(EVENT, INFO_CLIENT_GET_TEAMS_SUCCESS));
+        return entities;
+    }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/dto/EntityDataDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/dto/EntityDataDto.java
@@ -1,0 +1,13 @@
+package uk.gov.digital.ho.hocs.audit.export.infoclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class EntityDataDto {
+
+  @JsonProperty("title")
+  private String title;
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/dto/EntityDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/dto/EntityDto.java
@@ -1,0 +1,30 @@
+package uk.gov.digital.ho.hocs.audit.export.infoclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class EntityDto {
+
+  @JsonProperty("id")
+  private Long id;
+
+  @JsonProperty("uuid")
+  private UUID uuid;
+
+  @JsonProperty("simpleName")
+  private String simpleName;
+
+  @JsonProperty("data")
+  private EntityDataDto data;
+
+  @JsonProperty("entityListUUID")
+  private UUID entityListUUID;
+
+  @JsonProperty("active")
+  private boolean active;
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
@@ -166,7 +166,7 @@ public class AuditExportServiceTest {
         exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, false, false, null, null);
 
         verify(auditRepository, times(1)).findLastAuditDataByDateRangeAndEvents(from, to, ExportService.CASE_DATA_EVENTS, "a1");
-        verify(exportDataConverter, times(0)).convertData(any());
+        verify(exportDataConverter, times(0)).convertData(any(), any());
     }
 
     @Test
@@ -174,13 +174,13 @@ public class AuditExportServiceTest {
 
         when(infoClient.getCaseExportFields("MIN")).thenReturn(fields);
         when(auditRepository.findLastAuditDataByDateRangeAndEvents(any(), any(), eq(ExportService.CASE_DATA_EVENTS), any())).thenReturn(getCaseDataAuditData().stream());
-        when(exportDataConverter.convertData(any())).thenAnswer(a -> a.getArguments()[0]);
+        when(exportDataConverter.convertData(any(), any())).thenAnswer(a -> a.getArguments()[0]);
 
         OutputStream outputStream = new ByteArrayOutputStream();
         exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CASE_DATA, true, false, null, null);
 
         verify(auditRepository, times(1)).findLastAuditDataByDateRangeAndEvents(from, to, ExportService.CASE_DATA_EVENTS, "a1");
-        verify(exportDataConverter, times(getCaseDataAuditData().size())).convertData(any());
+        verify(exportDataConverter, times(getCaseDataAuditData().size())).convertData(any(), any());
     }
 
     @Test
@@ -203,14 +203,14 @@ public class AuditExportServiceTest {
         assertThat(row.get("event")).isEqualTo("CASE_NOTE_CREATED");
         assertThat(row.get("caseNoteType")).isEqualTo("Type1");
         assertThat(row.get("text")).isEqualTo("Note 1");
-        verify(exportDataConverter, times(0)).convertData(any());
+        verify(exportDataConverter, times(0)).convertData(any(), any());
     }
 
     @Test
     public void caseNotesExportShouldConvertHeadersAndData() throws IOException {
 
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), eq(ExportService.CASE_NOTES_EVENTS), any())).thenReturn(getCaseNotesAuditData().stream());
-        when(exportDataConverter.convertData(any())).thenAnswer(a -> a.getArguments()[0]);
+        when(exportDataConverter.convertData(any(), any())).thenAnswer(a -> a.getArguments()[0]);
         Set<String> expectedHeaders = Stream.of("timestamp", "event", "userId", "caseUuid", "uuid", "convertedCaseNoteType", "text").collect(Collectors.toSet());
         OutputStream outputStream = new ByteArrayOutputStream();
 
@@ -227,7 +227,7 @@ public class AuditExportServiceTest {
         assertThat(row.get("event")).isEqualTo("CASE_NOTE_CREATED");
         assertThat(row.get("convertedCaseNoteType")).isEqualTo("Type1");
         assertThat(row.get("text")).isEqualTo("Note 1");
-        verify(exportDataConverter, times(2)).convertData(any());
+        verify(exportDataConverter, times(2)).convertData(any(), any());
     }
 
     @Test
@@ -267,7 +267,7 @@ public class AuditExportServiceTest {
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(getTopicDataAuditData().stream());
         exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.TOPICS, false, false, null, null);
         verify(auditRepository, times(1)).findAuditDataByDateRangeAndEvents(from, to, ExportService.TOPIC_EVENTS, "a1");
-        verify(exportDataConverter, times(0)).convertData(any());
+        verify(exportDataConverter, times(0)).convertData(any(), any());
     }
 
     @Test
@@ -293,7 +293,7 @@ public class AuditExportServiceTest {
         OutputStream outputStream = new ByteArrayOutputStream();
         exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.CORRESPONDENTS, false, false, null, null);
         verify(auditRepository, times(1)).findAuditDataByDateRangeAndEvents(from, to, ExportService.CORRESPONDENT_EVENTS, "a1");
-        verify(exportDataConverter, times(0)).convertData(any());
+        verify(exportDataConverter, times(0)).convertData(any(), any());
     }
 
     @Test
@@ -314,7 +314,7 @@ public class AuditExportServiceTest {
         OutputStream outputStream = new ByteArrayOutputStream();
         exportService.auditExport(from.toLocalDate(), to.toLocalDate(), outputStream, caseType, ExportType.ALLOCATIONS, false, false, null, null);
         verify(auditRepository, times(1)).findAuditDataByDateRangeAndEvents(from, to, ExportService.ALLOCATION_EVENTS, "a1");
-        verify(exportDataConverter, times(0)).convertData(any());
+        verify(exportDataConverter, times(0)).convertData(any(), any());
     }
 
 


### PR DESCRIPTION
See https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-2441 "Convert database value to display value in extracts".
Some fields in the audit records store short codes from out entity lists. The requirement here for 3 specific entity lists and for MPAM client only. 

ExportDataConverter now needs to be aware of which client it is converting for, so the client code is now passed in from the ExportService.