### PR TITLE
HOCS-2461: change custom reports to stream

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryCustom.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryCustom.java
@@ -3,12 +3,12 @@ package uk.gov.digital.ho.hocs.audit.auditdetails.repository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Repository
 public interface AuditRepositoryCustom {
 
-    List<Object[]> getResultsFromView(String viewName);
-
+    Stream<Object[]> getResultsFromView(String viewName);
 
 }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryCustom.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryCustom.java
@@ -2,7 +2,6 @@ package uk.gov.digital.ho.hocs.audit.auditdetails.repository;
 
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 @Repository

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryImpl.java
@@ -2,19 +2,17 @@ package uk.gov.digital.ho.hocs.audit.auditdetails.repository;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import java.util.List;
+import java.util.stream.Stream;
 
 public class AuditRepositoryImpl implements AuditRepositoryCustom {
-
     @PersistenceContext
     private EntityManager em;
 
-
     @Override
-    public List<Object[]> getResultsFromView(String viewName) {
-        return (List<Object[]>) em.createNativeQuery(String.format("select * from %s", viewName)).unwrap(org.hibernate.query.NativeQuery.class)
-                .getResultList();
-
+    public Stream getResultsFromView(String viewName) {
+        return em.createNativeQuery(String.format("select * from %s", viewName))
+                .unwrap(org.hibernate.query.NativeQuery.class)
+                .getResultStream();
     }
 }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverter.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.HashMap;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
 import static uk.gov.digital.ho.hocs.audit.application.LogEvent.CSV_CUSTOM_CONVERTER_FAILURE;
@@ -31,7 +32,7 @@ public class CustomExportDataConverter {
         this.infoClient = infoClient;
         this.caseworkClient = caseworkClient;
 
-        initialiseAdapters();
+        adapters = new HashMap<>();
     }
 
     public List<String> getHeaders(ExportViewDto exportViewDto) {
@@ -99,7 +100,7 @@ public class CustomExportDataConverter {
         return false;
     }
 
-    private void initialiseAdapters() {
+    public void initialiseAdapters() {
         Set<UserDto> users = infoClient.getUsers();
         Set<TeamDto> teams = infoClient.getAllTeams();
         Set<UnitDto> units = infoClient.getUnits();

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverter.java
@@ -2,7 +2,6 @@ package uk.gov.digital.ho.hocs.audit.export;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
 import uk.gov.digital.ho.hocs.audit.application.LogEvent;
 import uk.gov.digital.ho.hocs.audit.export.adapter.*;
 import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
@@ -24,13 +23,15 @@ import static uk.gov.digital.ho.hocs.audit.application.LogEvent.CSV_CUSTOM_CONVE
 @Service
 public class CustomExportDataConverter {
 
-    private InfoClient infoClient;
-    private CaseworkClient caseworkClient;
+    private final InfoClient infoClient;
+    private final CaseworkClient caseworkClient;
     private Map<String, ExportViewFieldAdapter> adapters;
 
     public CustomExportDataConverter(InfoClient infoClient, CaseworkClient caseworkClient) {
         this.infoClient = infoClient;
         this.caseworkClient = caseworkClient;
+
+        initialiseAdapters();
     }
 
     public List<String> getHeaders(ExportViewDto exportViewDto) {
@@ -45,26 +46,17 @@ public class CustomExportDataConverter {
         return headers;
     }
 
-    public List<Object[]> convertData(List<Object[]> input, List<ExportViewFieldDto> fields) {
+    public Object[] convertData(Object[] input, List<ExportViewFieldDto> fields) {
+        Object[] convertedData = null;
 
-        if (!CollectionUtils.isEmpty(input)) {
-            initialiseAdapters();
-            List<Object[]> convertedData = new ArrayList<>();
-
-            for (Object[] row : input) {
-                convertedData.add(convertCustomDataRow(row, fields));
-            }
-
-            return convertedData;
-
+        if (input != null) {
+            convertedData = convertCustomDataRow(input, fields);
         }
 
-        return new ArrayList<>();
-
+        return convertedData;
     }
 
     private Object[] convertCustomDataRow(Object[] rawData, List<ExportViewFieldDto> fields) {
-
         List<String> results = new ArrayList<>();
         int index = 0;
         for (ExportViewFieldDto fieldDto : fields) {
@@ -74,14 +66,12 @@ public class CustomExportDataConverter {
             index++;
         }
 
-
         return results.toArray();
     }
 
     private String applyAdapters(Object data, List<ExportViewFieldAdapterDto> adaptersDtos) {
-
-
         Object result = data;
+
         for (ExportViewFieldAdapterDto adapterDto : adaptersDtos) {
             ExportViewFieldAdapter adapterToUse = adapters.get(adapterDto.getType());
 
@@ -97,11 +87,9 @@ public class CustomExportDataConverter {
         }
 
         return result == null ? null : String.valueOf(result);
-
     }
 
     private boolean shouldHide(ExportViewFieldDto viewFieldDto) {
-
         for (ExportViewFieldAdapterDto adapterDto : viewFieldDto.getAdapters()) {
             if (ExportViewConstants.FIELD_ADAPTER_HIDDEN.equals(adapterDto.getType())) {
                 return true;
@@ -123,11 +111,9 @@ public class CustomExportDataConverter {
         adapterList.add(new UserFirstAndLastNameAdapter(users));
         adapterList.add(new UnitNameAdapter(teams, units));
 
-
         adapterList.add(new TopicNameAdapter(topics));
         adapterList.add(new TeamNameAdapter(teams));
 
         adapters = adapterList.stream().collect(Collectors.toMap(ExportViewFieldAdapter::getAdapterType, adapter -> adapter));
-
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
@@ -66,6 +66,8 @@ public class CustomExportService {
                 substitutedHeaders = headerConverter.substitute(headers);
             }
 
+            customExportDataConverter.initialiseAdapters();
+
             try (CSVPrinter printer = new CSVPrinter(outputWriter, CSVFormat.DEFAULT.withHeader(substitutedHeaders.toArray(new String[substitutedHeaders.size()])))) {
                 retrieveAuditData(exportViewDto.getCode())
                         .forEach(data -> {

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
@@ -1,8 +1,10 @@
 package uk.gov.digital.ho.hocs.audit.export;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.protocol.HTTP;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.digital.ho.hocs.audit.auditdetails.exception.EntityPermissionException;
@@ -141,11 +143,11 @@ public class DataExportResource {
         }
     }
 
-    @GetMapping(value = "/export/custom/{code}")
+    @GetMapping(value = "/export/custom/{code}", produces = "text/csv;charset=UTF-8")
     public @ResponseBody
-    void getCustomDataExport(@PathVariable("code") String code, HttpServletResponse response,
+    void getCustomDataExport(HttpServletResponse response,
+                             @PathVariable("code") String code,
                              @RequestParam(name = "convertHeader", defaultValue = "false") boolean convertHeader) {
-
         try {
             customExportService.customExport(response, code, convertHeader);
             response.setStatus(200);

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverterTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverterTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CustomExportDataConverterTest {
-
     private static final String PERMISSION_1 = "permission_name1";
     private static final String VIEW_CODE_1 = "view_name1";
     private static final String VIEW_DISPLAY_NAME_1 = "display_name1";
@@ -33,7 +32,6 @@ public class CustomExportDataConverterTest {
     private static final String FIELD_NAME_E = "FieldE";
     private static final String FIELD_NAME_F = "FieldF";
     private static final String FIELD_NAME_G = "FieldG";
-
 
     private static final String USER1_ID = UUID.randomUUID().toString();
     private static final String USER1_USERNAME = "user-Bob";
@@ -67,7 +65,6 @@ public class CustomExportDataConverterTest {
 
     private CustomExportDataConverter converter;
 
-
     @Before
     public void before() {
         Set<UserDto> users = buildUsers();
@@ -81,32 +78,29 @@ public class CustomExportDataConverterTest {
         when(caseworkClient.getAllCaseTopics()).thenReturn(topics);
 
         converter = new CustomExportDataConverter(infoClient, caseworkClient);
+        converter.initialiseAdapters();
     }
 
     @Test
     public void getHeaders() {
         ExportViewDto exportViewDto = buildExportView1();
 
-
         List<String> results = converter.getHeaders(exportViewDto);
 
         assertThat(results).isNotNull();
         assertThat(results.size()).isEqualTo(2);
         assertThat(results).contains(FIELD_NAME_A, FIELD_NAME_B);
-
     }
 
     @Test
     public void getHeaders_Hidden() {
         ExportViewDto exportViewDto = buildExportView2();
 
-
         List<String> results = converter.getHeaders(exportViewDto);
 
         assertThat(results).isNotNull();
         assertThat(results.size()).isEqualTo(1);
         assertThat(results).contains(FIELD_NAME_A);
-
     }
 
     @Test
@@ -164,7 +158,6 @@ public class CustomExportDataConverterTest {
     }
 
     private ExportViewDto buildExportView3() {
-
         ExportViewFieldAdapterDto userEmailAdapter = new ExportViewFieldAdapterDto(null, null, null, ExportViewConstants.FIELD_ADAPTER_USER_EMAIL);
         ExportViewFieldAdapterDto usernameAdapter = new ExportViewFieldAdapterDto(null, null, null, ExportViewConstants.FIELD_ADAPTER_USERNAME);
         ExportViewFieldAdapterDto userFirstAndLastName = new ExportViewFieldAdapterDto(null, null, null, ExportViewConstants.FIELD_ADAPTER_FIRST_AND_LAST_NAME);

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverterTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportDataConverterTest.java
@@ -13,6 +13,8 @@ import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.*;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -68,6 +70,16 @@ public class CustomExportDataConverterTest {
 
     @Before
     public void before() {
+        Set<UserDto> users = buildUsers();
+        Set<TeamDto> teams = buildTeams();
+        Set<UnitDto> units = buildUnits();
+        Set<GetTopicResponse> topics = buildTopics();
+
+        when(infoClient.getUsers()).thenReturn(users);
+        when(infoClient.getAllTeams()).thenReturn(teams);
+        when(infoClient.getUnits()).thenReturn(units);
+        when(caseworkClient.getAllCaseTopics()).thenReturn(topics);
+
         converter = new CustomExportDataConverter(infoClient, caseworkClient);
     }
 
@@ -100,20 +112,11 @@ public class CustomExportDataConverterTest {
     @Test
     public void convertData() {
         ExportViewDto exportViewDto = buildExportView3();
+        Stream<Object[]> input = buildInputData();
 
-        Set<UserDto> users = buildUsers();
-        Set<TeamDto> teams = buildTeams();
-        Set<UnitDto> units = buildUnits();
-        Set<GetTopicResponse> topics = buildTopics();
-        List<Object[]> input = buildInputData();
-
-        when(infoClient.getUsers()).thenReturn(users);
-        when(infoClient.getAllTeams()).thenReturn(teams);
-        when(infoClient.getUnits()).thenReturn(units);
-        when(caseworkClient.getAllCaseTopics()).thenReturn(topics);
-
-
-        List<Object[]> results = converter.convertData(input, exportViewDto.getFields());
+        List<Object[]> results = input
+                .map(result -> converter.convertData(result, exportViewDto.getFields()))
+                .collect(Collectors.toList());
 
         assertThat(results).isNotNull();
         assertThat(results.size()).isEqualTo(2);
@@ -210,7 +213,7 @@ public class CustomExportDataConverterTest {
     }
 
 
-    private List<Object[]> buildInputData() {
+    private Stream<Object[]> buildInputData() {
         List<Object[]> inputData = new ArrayList<>();
         Object[] row1 = new Object[7];
         Object[] row2 = new Object[7];
@@ -233,6 +236,6 @@ public class CustomExportDataConverterTest {
         inputData.add(row1);
         inputData.add(row2);
 
-        return inputData;
+        return inputData.stream();
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportServiceTest.java
@@ -74,7 +74,6 @@ public class CustomExportServiceTest {
         checkNoMoreInteractions();
     }
 
-
     @Test()
     public void customExport() throws IOException {
         Stream<Object[]> inputData = buildInputData();
@@ -95,6 +94,7 @@ public class CustomExportServiceTest {
         verify(infoClient).getExportView(VIEW_CODE_1);
         verify(auditRepository).getResultsFromView(VIEW_CODE_1);
         verify(customExportDataConverter, times(2)).convertData(any(), any());
+        verify(customExportDataConverter).initialiseAdapters();
         verify(requestData).roles();
         verify(customExportDataConverter).getHeaders(exportViewDto);
         verify(passThroughHeaderConverter).substitute(anyList());

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/DataExportResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/DataExportResourceTest.java
@@ -30,7 +30,7 @@ public class DataExportResourceTest {
     private DataExportResource dataExportResource;
 
     @Before
-    public void before() {
+    public void before() throws IOException {
         dataExportResource = new DataExportResource(exportService, customExportService);
     }
 
@@ -253,31 +253,38 @@ public class DataExportResourceTest {
     public void getCustomDataExport() throws IOException {
         String customReportCode = "Code123";
 
-        dataExportResource.getCustomDataExport(customReportCode, response, true);
+        dataExportResource.getCustomDataExport(response, customReportCode, true);
 
         verify(customExportService).customExport(response, customReportCode, true);
         verify(response).setStatus(200);
+
         checkNoMoreInteractions();
     }
+
 
     @Test
     public void getCustomDataExport_HttpClientErrorException() throws IOException {
         String customReportCode = "Code123";
 
-        doThrow(new HttpClientErrorException(HttpStatus.I_AM_A_TEAPOT)).when(customExportService).customExport(response, customReportCode, true);
-        dataExportResource.getCustomDataExport(customReportCode, response, true);
+        doThrow(new HttpClientErrorException(HttpStatus.I_AM_A_TEAPOT))
+                .when(customExportService)
+                .customExport(response, customReportCode, true);
+        dataExportResource.getCustomDataExport(response, customReportCode, true);
 
-        verify(customExportService).customExport(response, customReportCode, true);
+        verify(customExportService, atLeastOnce()).customExport(response, customReportCode, true);
         verify(response).setStatus(418);
         checkNoMoreInteractions();
     }
+
 
     @Test
     public void getCustomDataExport_EntityPermissionException() throws IOException {
         String customReportCode = "Code123";
 
-        doThrow(new EntityPermissionException("Test exception")).when(customExportService).customExport(response, customReportCode, true);
-        dataExportResource.getCustomDataExport(customReportCode, response, true);
+        doThrow(new EntityPermissionException("Test exception"))
+                .when(customExportService)
+                .customExport(response, customReportCode, true);
+        dataExportResource.getCustomDataExport(response, customReportCode, true);
 
         verify(customExportService).customExport(response, customReportCode, true);
         verify(response).setStatus(403);
@@ -288,8 +295,10 @@ public class DataExportResourceTest {
     public void getCustomDataExport_nonHttpClientErrorException() throws IOException {
         String customReportCode = "Code123";
 
-        doThrow(new IllegalArgumentException("Dummy exception")).when(customExportService).customExport(response, customReportCode, true);
-        dataExportResource.getCustomDataExport(customReportCode, response, true);
+        doThrow(new IllegalArgumentException("Dummy exception"))
+                .when(customExportService)
+                .customExport(response, customReportCode, true);
+        dataExportResource.getCustomDataExport(response, customReportCode, true);
 
         verify(customExportService).customExport(response, customReportCode, true);
         verify(response).setStatus(500);


### PR DESCRIPTION
Currently on the database we pull all the data and then do the 
data conversion. This leads to a big lead time on the download as 
we currently handle this linearly. 
This change makes it so that we stream the data from the custom 
view and thus start building the file as the data comes through.