### PR TITLE
Revert "HOCS-2424 Add temporary timestamp logging for extract"

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/application/ZonedDateTimeConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/application/ZonedDateTimeConverter.java
@@ -1,6 +1,5 @@
 package uk.gov.digital.ho.hocs.audit.application;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
@@ -12,7 +11,6 @@ import java.time.format.DateTimeFormatter;
  * Converter that for the user to pass in a local date time and to return the offset
  * against a specified time zone.
  */
-@Slf4j
 public class ZonedDateTimeConverter {
 
     private static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS";
@@ -41,14 +39,11 @@ public class ZonedDateTimeConverter {
      * @return the offsetted date time string
      */
     public String convert(final LocalDateTime localDateTime) {
-        log.info("Timestamp before convert: {}", localDateTime);
         final ZonedDateTime zonedDateTime =
                 localDateTime
                         .atZone(ZoneId.systemDefault())
                         .withZoneSameInstant(specifiedTimeZoneId);
-        log.info("Timestamp after time zone: {}", zonedDateTime);
-        log.info("Timestamp after toLocalDateTime(): {}", zonedDateTime.toLocalDateTime());
-        log.info("Timestamp after formatting: {}", zonedDateTime.toLocalDateTime().format(dateTimeFormatter));
+
         return zonedDateTime.toLocalDateTime().format(dateTimeFormatter);
     }
 


### PR DESCRIPTION
Reverts UKHomeOffice/hocs-audit#76
This issue has been resolved and the hotfix has been removed from production.
Reverting as logs no longer required.