### PR TITLE
HOCS-2461: change implementation to use stream

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryImpl.java
@@ -1,5 +1,9 @@
 package uk.gov.digital.ho.hocs.audit.auditdetails.repository;
 
+import lombok.NonNull;
+import org.hibernate.jpa.QueryHints;
+import org.hibernate.query.Query;
+
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.util.stream.Stream;
@@ -9,10 +13,11 @@ public class AuditRepositoryImpl implements AuditRepositoryCustom {
     private EntityManager em;
 
     @Override
-    public Stream getResultsFromView(String viewName) {
-        return em.createNativeQuery(String.format("select * from %s", viewName))
-                .unwrap(org.hibernate.query.NativeQuery.class)
-                .getResultStream();
+    public Stream<Object[]> getResultsFromView(@NonNull final String viewName) {
+        return em.createNativeQuery(String.format("SELECT * FROM %s", viewName))
+                .setHint(QueryHints.HINT_FETCH_SIZE, 50 )
+                .unwrap(Query.class)
+                .stream();
     }
 }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
@@ -46,6 +46,7 @@ public class CustomExportService {
         this.requestData = requestData;
     }
 
+    @Transactional(readOnly = true, timeout = 300)
     public void customExport(HttpServletResponse response, String code, boolean convertHeader) throws IOException {
         ExportViewDto exportViewDto = infoClient.getExportView(code);
 
@@ -91,7 +92,6 @@ public class CustomExportService {
         }
     }
 
-    @Transactional(readOnly = true, timeout = 300)
     Stream<Object[]> retrieveAuditData(@NonNull String exportViewCode) {
         return auditRepository
                 .getResultsFromView(exportViewCode);


### PR DESCRIPTION
Currently we use the 'getResultStream()' which underneath 
actually does 'getResultList().stream()' which is sequential.
This change is to use the stream directly.