### PR TITLE
HOCS-2624 start streaming file after writing headers

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryImpl.java
@@ -15,7 +15,7 @@ public class AuditRepositoryImpl implements AuditRepositoryCustom {
     @Override
     public Stream<Object[]> getResultsFromView(@NonNull final String viewName) {
         return em.createNativeQuery(String.format("SELECT * FROM %s", viewName))
-                .setHint(QueryHints.HINT_FETCH_SIZE, 50 )
+                .setHint(QueryHints.HINT_FETCH_SIZE, 20 )
                 .unwrap(Query.class)
                 .stream();
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
@@ -69,7 +69,11 @@ public class CustomExportService {
 
             customExportDataConverter.initialiseAdapters();
 
-            try (CSVPrinter printer = new CSVPrinter(outputWriter, CSVFormat.DEFAULT.withHeader(substitutedHeaders.toArray(new String[substitutedHeaders.size()])))) {
+            try (CSVPrinter printer =
+                         new CSVPrinter(outputWriter, CSVFormat.DEFAULT.withHeader(substitutedHeaders.toArray(new String[substitutedHeaders.size()])))) {
+                // Immediately flush the output writer so the file starts downloading immediately.
+                outputWriter.flush();
+
                 retrieveAuditData(exportViewDto.getCode())
                         .forEach(data -> {
                             Object[] converted = customExportDataConverter.convertData(data, exportViewDto.getFields());


### PR DESCRIPTION
At present we wait for the first set of data to come through before we start streaming the custom audit file to the user. 

This change flushes the file to the user straight after creating it, bypassing the initial cut off on the file download if the results take longer than 2 minutes to return. 

This PR also lowers the fetch size from 50 to 20 to assist with bringing this down too.

