### PR TITLE
HOCS-2310: change custom export route

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/CustomExportService.java
@@ -39,8 +39,6 @@ public class CustomExportService {
     private final HeaderConverter headerConverter;
     private RequestData requestData;
 
-    private final String REFRESH_MATERIALISED_VIEW_ROLE = "REFRESH_MATERIALISED_VIEW_USER";
-
     public CustomExportService(AuditRepository auditRepository, InfoClient infoClient, CustomExportDataConverter customExportDataConverter, HeaderConverter headerConverter, RequestData requestData) {
         this.auditRepository = auditRepository;
         this.infoClient = infoClient;
@@ -111,13 +109,8 @@ public class CustomExportService {
 
     @Transactional
     public int refreshMaterialisedView(final String viewName) {
-        if (!requestData.roles().contains(REFRESH_MATERIALISED_VIEW_ROLE)) {
-            log.error("Cannot export due to permission not assigned to the user, user {}, permission REFRESH_MATERIALISED_VIEW_USER", requestData.userId(), REFRESH_MATERIALISED_VIEW_ROLE);
-            throw new EntityPermissionException("No permission to refresh materialised view");
-        } else {
-            log.info("Refreshing materialise view '{}', event {}", viewName, value(EVENT, REFRESH_MATERIALISED_VIEW));
-            return auditRepository.refreshMaterialisedView(viewName);
-        }
+        log.info("Refreshing materialise view '{}', event {}", viewName, value(EVENT, REFRESH_MATERIALISED_VIEW));
+        return auditRepository.refreshMaterialisedView(viewName);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
@@ -160,14 +160,13 @@ public class DataExportResource {
                 response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
             }
         }
-
     }
 
-    @PostMapping(value = "/export/custom/{viewName}/refresh")
+    @PostMapping(value = "/admin/export/custom/{viewName}/refresh")
     public @ResponseBody void refreshMaterialisedView(HttpServletResponse response, @PathVariable("viewName") final String viewName) {
         try {
             customExportService.refreshMaterialisedView(viewName);
-            response.setStatus(200);
+            response.setStatus(HttpStatus.OK.value());
         } catch (Exception ex) {
             log.error("Error refreshing materialised view {}: {}", viewName, ex.getMessage());
             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/CustomExportServiceTest.java
@@ -119,15 +119,6 @@ public class CustomExportServiceTest {
         return inputData.stream();
     }
 
-    @Test(expected = EntityPermissionException.class)
-    public void refreshMaterialisedView_NoPermission() {
-        when(requestData.roles()).thenReturn(new ArrayList<>());
-
-        customExportService.refreshMaterialisedView(VIEW_CODE_1);
-
-        checkNoMoreInteractions();
-    }
-
     private List<Object[]> buildOutputData() {
         List<Object[]> inputData = new ArrayList<>();
         Object[] row1 = new Object[3];


### PR DESCRIPTION
This change changes the routing so that it doesn't go through keycloak gatekeeper. This then allows us to use basicauth instead of fudging our way around roles and whitelisting the endpoint. As we are not routing the endpoint through Keycloak anymore and the endpoint itself is not external. We also don't need to protect this endpoint anymore.