### PR TITLE
HOCS 3114 Extract Date Format Error

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
@@ -39,6 +39,7 @@ public class ExportService {
     private final InfoClient infoClient;
     private final ExportDataConverter exportDataConverter;
     private final HeaderConverter headerConverter;
+    private final MalformedDateConverter malformedDateConverter;
     public static final String[] CASE_DATA_EVENTS = {"CASE_CREATED", "CASE_UPDATED", "CASE_COMPLETED"};
     public static final String[] CASE_NOTES_EVENTS = {"CASE_NOTE_CREATED", "CASE_NOTE_UPDATED", "CASE_NOTE_DELETED"};
     public static final String[] SOMU_TYPE_EVENTS = {"SOMU_ITEM_UPDATED", "SOMU_ITEM_CREATED"};
@@ -47,12 +48,13 @@ public class ExportService {
     public static final String[] ALLOCATION_EVENTS = {"STAGE_ALLOCATED_TO_TEAM", "STAGE_CREATED", "STAGE_RECREATED", "STAGE_COMPLETED", "STAGE_ALLOCATED_TO_USER", "STAGE_UNALLOCATED_FROM_USER"};
 
     public ExportService(AuditRepository auditRepository, ObjectMapper mapper, InfoClient infoClient, ExportDataConverter exportDataConverter,
-                         HeaderConverter headerConverter) {
+                         HeaderConverter headerConverter, MalformedDateConverter malformedDateConverter) {
         this.auditRepository = auditRepository;
         this.mapper = mapper;
         this.infoClient = infoClient;
         this.exportDataConverter = exportDataConverter;
         this.headerConverter = headerConverter;
+        this.malformedDateConverter = malformedDateConverter;
     }
 
     @Transactional(readOnly = true)
@@ -108,6 +110,7 @@ public class ExportService {
                     if (convert){
                         parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
+                    parsedAudit = malformedDateConverter.correctDateFields(parsedAudit);
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
                 } catch (Exception e) {
@@ -159,6 +162,7 @@ public class ExportService {
                     if (convert){
                         parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
+                    parsedAudit = malformedDateConverter.correctDateFields(parsedAudit);
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
                 } catch (Exception e) {
@@ -217,6 +221,7 @@ public class ExportService {
                         if (convert) {
                             parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                         }
+                        parsedAudit = malformedDateConverter.correctDateFields(parsedAudit);
                         printer.printRecord(parsedAudit);
                         outputWriter.flush();
                     }
@@ -319,6 +324,7 @@ public class ExportService {
                     if (convert){
                         parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
+                    parsedAudit = malformedDateConverter.correctDateFields(parsedAudit);
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
                 } catch (IOException e) {
@@ -378,6 +384,7 @@ public class ExportService {
                     if (convert){
                         parsedAudit = exportDataConverter.convertData(parsedAudit, caseTypeCode);
                     }
+                    parsedAudit = malformedDateConverter.correctDateFields(parsedAudit);
                     printer.printRecord(parsedAudit);
                     outputWriter.flush();
                 } catch (IOException e) {

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/MalformedDateConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/MalformedDateConverter.java
@@ -1,0 +1,18 @@
+package uk.gov.digital.ho.hocs.audit.export;
+
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.audit.export.adapter.DateAdapter;
+
+@Service
+public class MalformedDateConverter {
+
+    private DateAdapter dateAdapter = new DateAdapter();
+
+    public String[] correctDateFields(String[] auditData) {
+        for (int i = 0; i < auditData.length; i++){
+            auditData[i] = dateAdapter.convert(auditData[i]);
+        }
+        return auditData;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/adapter/DateAdapter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/adapter/DateAdapter.java
@@ -1,0 +1,59 @@
+package uk.gov.digital.ho.hocs.audit.export.adapter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static uk.gov.digital.ho.hocs.audit.export.infoclient.ExportViewConstants.*;
+import static uk.gov.digital.ho.hocs.audit.export.infoclient.ExportViewConstants.DATE_SECTION.*;
+
+
+@Slf4j
+public class DateAdapter implements ExportViewFieldAdapter {
+
+    @Override
+    public String getAdapterType() {
+        return FIELD_ADAPTER_DATE;
+    }
+
+    @Override
+    public String convert(Object input) {
+        if (input instanceof String) {
+            String date = (String)input;
+            if (date.matches(MALFORMED_DATE_REGEX)) {
+                String year = retrieveSection(YEAR, date);
+                String month = retrieveSection(MONTH, date);
+                String day = retrieveSection(DAY, date);
+                if (year != null && month != null && day != null) {
+                    return year.substring(year.length() - YEAR_DIGITS) + "-" +
+                           month.substring(month.length() - MONTH_DIGITS) + "-" +
+                           day.substring(day.length() - DAY_DIGITS);
+                }
+            }
+            return date;
+        }
+        return null;
+    }
+
+    protected String retrieveSection(DATE_SECTION section, String date) {
+        switch (section) {
+        case DAY:
+            return extract(date, EXTRACT_DAY_REGEX);
+        case MONTH:
+            return extract(date, EXTRACT_MONTH_REGEX);
+        case YEAR:
+            return extract(date, EXTRACT_YEAR_REGEX);
+        }
+        return null;
+    }
+
+    private String extract(String date, String pattern) {
+        Pattern pat = Pattern.compile(pattern);
+        Matcher matcher = pat.matcher(date);
+        if (matcher.find()) {
+            return matcher.group(pattern.equals(EXTRACT_DAY_REGEX) ? 1 : 0);
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/ExportViewConstants.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/ExportViewConstants.java
@@ -2,6 +2,16 @@ package uk.gov.digital.ho.hocs.audit.export.infoclient;
 
 public interface ExportViewConstants {
 
+        enum DATE_SECTION {DAY, MONTH, YEAR};
+        int YEAR_DIGITS = 4;
+        int MONTH_DIGITS = 2;
+        int DAY_DIGITS = 2;
+
+        String MALFORMED_DATE_REGEX = "^(\\d{4,5})\\-(0*[1-9]|0*1[12])\\-(0*0[1-9]|0*[12][0-9]|0*3[01])$";
+        String EXTRACT_YEAR_REGEX = "^\\d+?(?=\\-)";
+        String EXTRACT_MONTH_REGEX = "(?<=\\-)\\d+(?=\\-)";
+        String EXTRACT_DAY_REGEX = "(?:[^\\-]*\\-){2}(\\d+)";
+
         String FIELD_ADAPTER_HIDDEN = "hidden";
         String FIELD_ADAPTER_USER_EMAIL = "userEmailAdapter";
         String FIELD_ADAPTER_USERNAME = "usernameAdapter";
@@ -9,4 +19,5 @@ public interface ExportViewConstants {
         String FIELD_ADAPTER_TEAM_NAME = "teamNameAdapter";
         String FIELD_ADAPTER_UNIT_NAME = "unitNameAdapter";
         String FIELD_ADAPTER_TOPIC_NAME = "topicNameAdapter";
+        String FIELD_ADAPTER_DATE = "dateAdapter";
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
@@ -48,6 +48,9 @@ public class AuditExportServiceTest {
     private HeaderConverter passThroughHeaderConverter;
 
     @Mock
+    private MalformedDateConverter malformedDateConverter;
+
+    @Mock
     private HeaderConverter headerConverter;
 
     @Mock
@@ -107,9 +110,9 @@ public class AuditExportServiceTest {
                 return (List<String>) args[0];
             }
         });
-        exportService = new ExportService(auditRepository, mapper, infoClient, exportDataConverter, passThroughHeaderConverter);
-        exportServiceTestHeaders = new ExportService(auditRepository, mapper, infoClient, exportDataConverter, headerConverter);
-        exportServiceCaseNotesHeaders = new ExportService(auditRepository, mapper, infoClient, exportDataConverter, caseNoteHeaderConverter);
+        exportService = new ExportService(auditRepository, mapper, infoClient, exportDataConverter, passThroughHeaderConverter, malformedDateConverter);
+        exportServiceTestHeaders = new ExportService(auditRepository, mapper, infoClient, exportDataConverter, headerConverter, malformedDateConverter);
+        exportServiceCaseNotesHeaders = new ExportService(auditRepository, mapper, infoClient, exportDataConverter, caseNoteHeaderConverter, malformedDateConverter);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/adapter/DateAdapterTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/adapter/DateAdapterTest.java
@@ -1,0 +1,58 @@
+package uk.gov.digital.ho.hocs.audit.export.adapter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.digital.ho.hocs.audit.export.infoclient.ExportViewConstants.*;
+import static uk.gov.digital.ho.hocs.audit.export.infoclient.ExportViewConstants.DATE_SECTION.*;
+
+@RunWith (SpringRunner.class)
+public class DateAdapterTest {
+
+    String TEXT_DATA = "ABC-12-EE";
+    String SIMILAR_DATE = "2021.02.11";
+    String VALID_DATE = "2021-02-28";
+    String MALFORMED_DATE_Y = "02021-01-22";
+    String MALFORMED_DATE_M = "2022-002-23";
+    String MALFORMED_DATE_D = "2023-03-024";
+    String MALFORMED_DATE_YMD = "02024-004-025";
+
+    @Test
+    public void shouldFindMalformedDatesButNotNonDates() {
+        assertThat(TEXT_DATA.matches(MALFORMED_DATE_REGEX)).isFalse();
+        assertThat(SIMILAR_DATE.matches(MALFORMED_DATE_REGEX)).isFalse();
+        assertThat(VALID_DATE.matches(MALFORMED_DATE_REGEX)).isTrue();
+        
+        assertThat(MALFORMED_DATE_D.matches(MALFORMED_DATE_REGEX)).isTrue();
+        assertThat(MALFORMED_DATE_M.matches(MALFORMED_DATE_REGEX)).isTrue();
+        assertThat(MALFORMED_DATE_Y.matches(MALFORMED_DATE_REGEX)).isTrue();
+        assertThat(MALFORMED_DATE_YMD.matches(MALFORMED_DATE_REGEX)).isTrue();
+    }
+
+    @Test
+    public void shouldExtractPartsOfDate() {
+        DateAdapter dateAdapter = new DateAdapter();
+        assertThat(dateAdapter.retrieveSection(YEAR, MALFORMED_DATE_Y)).isEqualTo("02021");
+        assertThat(dateAdapter.retrieveSection(MONTH, MALFORMED_DATE_M)).isEqualTo("002");
+        assertThat(dateAdapter.retrieveSection(DAY, MALFORMED_DATE_D)).isEqualTo("024");
+
+        assertThat(dateAdapter.retrieveSection(DAY, MALFORMED_DATE_Y)).isEqualTo("22");
+        assertThat(dateAdapter.retrieveSection(YEAR, MALFORMED_DATE_M)).isEqualTo("2022");
+        assertThat(dateAdapter.retrieveSection(MONTH, MALFORMED_DATE_D)).isEqualTo("03");
+    }
+
+    @Test
+    public void shouldConvertDates() {
+        DateAdapter dateAdapter = new DateAdapter();
+        assertThat(dateAdapter.convert(TEXT_DATA)).isEqualTo(TEXT_DATA);
+        assertThat(dateAdapter.convert(SIMILAR_DATE)).isEqualTo(SIMILAR_DATE);
+        assertThat(dateAdapter.convert(VALID_DATE)).isEqualTo("2021-02-28");
+        assertThat(dateAdapter.convert(MALFORMED_DATE_Y)).isEqualTo("2021-01-22");
+        assertThat(dateAdapter.convert(MALFORMED_DATE_M)).isEqualTo("2022-02-23");
+        assertThat(dateAdapter.convert(MALFORMED_DATE_D)).isEqualTo("2023-03-24");
+        assertThat(dateAdapter.convert(MALFORMED_DATE_YMD)).isEqualTo("2024-04-25");
+    }
+
+}


### PR DESCRIPTION
Adapter added for correcting malformed date fields (can be used in custom forms, but not implemented as custom already formats dates).
Implemented date format corrections for all other reports.
Tests added for adapter functionality.