### PR TITLE
Java11 migration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,12 +12,12 @@ services:
 
 steps:
   - name: build project
-    image: quay.io/ukhomeofficedigital/openjdk8
+    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
     commands:
       - ./gradlew assemble --no-daemon
 
   - name: test project
-    image: quay.io/ukhomeofficedigital/openjdk8
+    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
     environment:
       DB_HOST: "postgres"
     commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM quay.io/ukhomeofficedigital/openjdk8
-
+FROM quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
 
 ENV USER user_hocs_audit
 ENV USER_ID 1000

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        springBootVersion = '2.0.5.RELEASE'
-        camelVersion = '2.22.0'
+        springBootVersion = '2.1.4.RELEASE'
+        camelVersion = '2.23.4'
     }
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -28,42 +28,44 @@ build.dependsOn(copyLombok)
 
 group = 'uk.gov.digital.ho.hocs'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = 1.8
+sourceCompatibility = '11'
+targetCompatibility = '11'
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web") {
-        exclude module: "spring-boot-starter-tomcat"
+    implementation('org.springframework.boot:spring-boot-starter-web') {
+        exclude(module: 'spring-boot-starter-tomcat')
     }
 
-    compile('org.springframework.boot:spring-boot-starter-undertow')
-    compile('net.logstash.logback:logstash-logback-encoder:5.1')
-    compile('org.springframework.boot:spring-boot-starter-json')
-    compile('org.springframework.boot:spring-boot-starter-actuator')
-    compile('org.springframework.boot:spring-boot-starter-data-jpa')
+    implementation('org.springframework.boot:spring-boot-starter-undertow')
+    implementation('net.logstash.logback:logstash-logback-encoder:5.1')
+    implementation('org.springframework.boot:spring-boot-starter-json')
+    implementation('org.springframework.boot:spring-boot-starter-actuator')
+    implementation('org.springframework.boot:spring-boot-starter-data-jpa')
 
     implementation('com.github.ben-manes.caffeine:caffeine')
-    compile group: 'org.apache.camel', name: 'camel-spring-boot', version: camelVersion
-    compile group: 'org.apache.camel', name: 'camel-jackson', version: camelVersion
-    compile group: 'org.apache.camel', name: 'camel-aws', version: camelVersion
-    compile group: 'org.apache.camel', name: 'camel-http4', version: camelVersion
-    compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.6'
-    compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.380'
 
-    compile('org.flywaydb:flyway-core')
-    compile('org.apache.commons:commons-csv:1.5')
+    implementation group: 'org.apache.camel', name: 'camel-spring-boot', version: camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-jackson', version: camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-aws', version: camelVersion
+    implementation group: 'org.apache.camel', name: 'camel-http4', version: camelVersion
+    implementation group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.6'
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.380'
 
-    runtime('org.postgresql:postgresql')
+    implementation('org.flywaydb:flyway-core')
+    implementation('org.apache.commons:commons-csv:1.5')
+
+    runtimeOnly('org.postgresql:postgresql')
 
     compileOnly('org.projectlombok:lombok')
+    annotationProcessor 'org.projectlombok:lombok'
 
-    testCompile group: 'org.apache.camel', name: 'camel-test-spring', version: camelVersion
-    testCompile('org.springframework.boot:spring-boot-starter-test')
-    testCompile('org.assertj:assertj-core')
+    testImplementation group: 'org.apache.camel', name: 'camel-test-spring', version: camelVersion
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation('org.assertj:assertj-core')
 
-    compile "com.google.code.gson:gson:2.8.5"
-    
+    implementation "com.google.code.gson:gson:2.8.5"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,11 @@ buildscript {
         springBootVersion = '2.1.4.RELEASE'
         camelVersion = '2.23.4'
     }
+
     repositories {
         mavenCentral()
     }
+
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Apr 26 11:56:12 BST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip


### PR DESCRIPTION
This pull request contains the following changes: 

- Bring gradle version to latest version
- Change docker image to OpenJDK 11 (in line with other services)
- Bump dependency versions of spring boot and camel 
- Migrate gradle.build to use `implementation` over `compile`
- Change drone pipeline to use OpenJDK 11 for building and testing