### PR TITLE
Revert "Java11 migration (#91)"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,12 +12,12 @@ services:
 
 steps:
   - name: build project
-    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+    image: quay.io/ukhomeofficedigital/openjdk8
     commands:
       - ./gradlew assemble --no-daemon
 
   - name: test project
-    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+    image: quay.io/ukhomeofficedigital/openjdk8
     environment:
       DB_HOST: "postgres"
     commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/openjdk8
+FROM quay.io/ukhomeofficedigital/openjdk8:v1.8.0.212
 
 
 ENV USER user_hocs_audit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+FROM quay.io/ukhomeofficedigital/openjdk8
+
 
 ENV USER user_hocs_audit
 ENV USER_ID 1000

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,11 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.4.RELEASE'
-        camelVersion = '2.23.4'
+        springBootVersion = '2.0.5.RELEASE'
+        camelVersion = '2.22.0'
     }
-
     repositories {
         mavenCentral()
     }
-
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     }
@@ -30,44 +28,42 @@ build.dependsOn(copyLombok)
 
 group = 'uk.gov.digital.ho.hocs'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation('org.springframework.boot:spring-boot-starter-web') {
-        exclude(module: 'spring-boot-starter-tomcat')
+    compile("org.springframework.boot:spring-boot-starter-web") {
+        exclude module: "spring-boot-starter-tomcat"
     }
 
-    implementation('org.springframework.boot:spring-boot-starter-undertow')
-    implementation('net.logstash.logback:logstash-logback-encoder:5.1')
-    implementation('org.springframework.boot:spring-boot-starter-json')
-    implementation('org.springframework.boot:spring-boot-starter-actuator')
-    implementation('org.springframework.boot:spring-boot-starter-data-jpa')
+    compile('org.springframework.boot:spring-boot-starter-undertow')
+    compile('net.logstash.logback:logstash-logback-encoder:5.1')
+    compile('org.springframework.boot:spring-boot-starter-json')
+    compile('org.springframework.boot:spring-boot-starter-actuator')
+    compile('org.springframework.boot:spring-boot-starter-data-jpa')
 
     implementation('com.github.ben-manes.caffeine:caffeine')
+    compile group: 'org.apache.camel', name: 'camel-spring-boot', version: camelVersion
+    compile group: 'org.apache.camel', name: 'camel-jackson', version: camelVersion
+    compile group: 'org.apache.camel', name: 'camel-aws', version: camelVersion
+    compile group: 'org.apache.camel', name: 'camel-http4', version: camelVersion
+    compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.6'
+    compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.380'
 
-    implementation group: 'org.apache.camel', name: 'camel-spring-boot', version: camelVersion
-    implementation group: 'org.apache.camel', name: 'camel-jackson', version: camelVersion
-    implementation group: 'org.apache.camel', name: 'camel-aws', version: camelVersion
-    implementation group: 'org.apache.camel', name: 'camel-http4', version: camelVersion
-    implementation group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.6'
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.380'
+    compile('org.flywaydb:flyway-core')
+    compile('org.apache.commons:commons-csv:1.5')
 
-    implementation('org.flywaydb:flyway-core')
-    implementation('org.apache.commons:commons-csv:1.5')
-
-    runtimeOnly('org.postgresql:postgresql')
+    runtime('org.postgresql:postgresql')
 
     compileOnly('org.projectlombok:lombok')
-    annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation group: 'org.apache.camel', name: 'camel-test-spring', version: camelVersion
-    testImplementation('org.springframework.boot:spring-boot-starter-test')
-    testImplementation('org.assertj:assertj-core')
+    testCompile group: 'org.apache.camel', name: 'camel-test-spring', version: camelVersion
+    testCompile('org.springframework.boot:spring-boot-starter-test')
+    testCompile('org.assertj:assertj-core')
 
-    implementation "com.google.code.gson:gson:2.8.5"
+    compile "com.google.code.gson:gson:2.8.5"
+    
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Apr 26 11:56:12 BST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip


### PR DESCRIPTION
Issues were identified whereby spring boot would not recognise a 
correct route. As a result the ability to pull reports has been 
compromised. As a result we need to revert this migration while 
further research into the potential migration take place. 

This reverts commit c4bb74226a4681f1667b1c2b1b7b8ade0d7ff0ba.