### PR TITLE
HOCS-3083: UUID showing incorrectly in converted cases

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportDataConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportDataConverter.java
@@ -28,19 +28,20 @@ public class ExportDataConverter {
     private static final String[] MPAM_CODE_MAPPING_LISTS = { "MPAM_ENQUIRY_SUBJECTS", "MPAM_ENQUIRY_REASONS_ALL", "MPAM_BUS_UNITS_ALL" };
     private static final Set<String> MPAM_SHORT_CODES = Stream.of("b5", "b6").collect(Collectors.toCollection(HashSet::new));
 
-    private InfoClient infoClient;
-    private CaseworkClient caseworkClient;
-    private Map<String, String> uuidToName;
-    private Map<String, String> mpamCodeToName;
+    private final InfoClient infoClient;
+    private final CaseworkClient caseworkClient;
+    private final Map<String, String> uuidToName;
+    private final Map<String, String> mpamCodeToName;
 
     public ExportDataConverter(InfoClient infoClient, CaseworkClient caseworkClient) {
         this.infoClient = infoClient;
         this.caseworkClient = caseworkClient;
+
+        uuidToName = new HashMap<>();
+        mpamCodeToName = new HashMap<>();
     }
 
     public void initialise() {
-        uuidToName = new HashMap<>();
-
         Set<UserDto> users = infoClient.getUsers();
         users.forEach(user -> uuidToName.put(user.getId(), user.getUsername()));
 
@@ -55,8 +56,6 @@ public class ExportDataConverter {
 
         Set<GetCorrespondentOutlineResponse> correspondents = caseworkClient.getAllActiveCorrespondents();
         correspondents.forEach(corr -> uuidToName.put(corr.getUuid().toString(), corr.getFullname()));
-
-        mpamCodeToName = new HashMap<>();
 
         for (String listName : MPAM_CODE_MAPPING_LISTS) {
             Set<EntityDto> entities = infoClient.getEntitiesForList(listName);

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClient.java
@@ -46,13 +46,6 @@ public class InfoClient {
         return users;
     }
 
-    public UserDto getUser(String uuid) {
-        UserDto result = restHelper.get(serviceBaseURL, String.format("/user/%s", uuid), new ParameterizedTypeReference<>() {
-        });
-        log.info("Got userDto for user uuid {}, event {}", uuid, value(EVENT, INFO_CLIENT_GET_USER_SUCCESS));
-        return result;
-    }
-
     @Cacheable(value = "getSomuType", unless = "#result == null")
     public SomuTypeDto getSomuType(String caseType, String somuType) {
         SomuTypeDto somuTypeDto = restHelper.get(serviceBaseURL, String.format("/somuType/%s/%s", caseType, somuType), new ParameterizedTypeReference<>() {

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClient.java
@@ -32,23 +32,22 @@ public class InfoClient {
 
     @Cacheable(value = "getCaseTypes", unless = "#result == null")
     public Set<CaseTypeDto> getCaseTypes() {
-        Set<CaseTypeDto> response = restHelper.get(serviceBaseURL, "/caseType", new ParameterizedTypeReference<Set<CaseTypeDto>>() {
+        Set<CaseTypeDto> response = restHelper.get(serviceBaseURL, "/caseType",
+                new ParameterizedTypeReference<>() {
         });
         log.info("Got {} case types", response.size(), value(EVENT, INFO_CLIENT_GET_CASE_TYPES_SUCCESS));
         return response;
     }
 
-    @Cacheable(value = "getUsers", unless = "#result == null")
     public Set<UserDto> getUsers() {
-        Set<UserDto> users = restHelper.get(serviceBaseURL, "/users", new ParameterizedTypeReference<Set<UserDto>>() {
+        Set<UserDto> users = restHelper.get(serviceBaseURL, "/users", new ParameterizedTypeReference<>() {
         });
         log.info("Got Users {}", value(EVENT, INFO_CLIENT_GET_USERS_SUCCESS));
         return users;
     }
 
-    @Cacheable(value = "getUser", unless = "#result == null")
     public UserDto getUser(String uuid) {
-        UserDto result = restHelper.get(serviceBaseURL, String.format("/user/%s", uuid), new ParameterizedTypeReference<UserDto>() {
+        UserDto result = restHelper.get(serviceBaseURL, String.format("/user/%s", uuid), new ParameterizedTypeReference<>() {
         });
         log.info("Got userDto for user uuid {}, event {}", uuid, value(EVENT, INFO_CLIENT_GET_USER_SUCCESS));
         return result;
@@ -56,91 +55,84 @@ public class InfoClient {
 
     @Cacheable(value = "getSomuType", unless = "#result == null")
     public SomuTypeDto getSomuType(String caseType, String somuType) {
-        SomuTypeDto somuTypeDto = restHelper.get(serviceBaseURL, String.format("/somuType/%s/%s", caseType, somuType), new ParameterizedTypeReference<SomuTypeDto>() {
+        SomuTypeDto somuTypeDto = restHelper.get(serviceBaseURL, String.format("/somuType/%s/%s", caseType, somuType), new ParameterizedTypeReference<>() {
         });
         log.info("Got SomuType {}", somuType, value(EVENT, INFO_CLIENT_GET_SOMUTYPE_SUCCESS));
         return somuTypeDto;
     }
 
-    @Cacheable(value = "getTopics", unless = "#result == null")
     public Set<TopicDto> getTopics() {
-        Set<TopicDto> infoTopic = restHelper.get(serviceBaseURL, String.format("/topics"), new ParameterizedTypeReference<Set<TopicDto>>() {
+        Set<TopicDto> infoTopic = restHelper.get(serviceBaseURL, String.format("/topics"), new ParameterizedTypeReference<>() {
         });
         log.info("Got Topics", value(EVENT, INFO_CLIENT_GET_TOPIC_SUCCESS));
         return infoTopic;
     }
 
     public Set<TopicTeamDto> getTopicsWithTeams(String caseType) {
-        Set<TopicTeamDto> topicTeams = restHelper.get(serviceBaseURL, String.format("/topics/%s/teams", caseType), new ParameterizedTypeReference<Set<TopicTeamDto>>() {
+        Set<TopicTeamDto> topicTeams = restHelper.get(serviceBaseURL, String.format("/topics/%s/teams", caseType), new ParameterizedTypeReference<>() {
         });
         log.info("Got {} topics with teams", topicTeams.size(), value(EVENT, INFO_CLIENT_GET_TEAMS_SUCCESS));
         return topicTeams;
     }
 
-    @Cacheable(value = "getTeams", unless = "#result == null")
     public Set<TeamDto> getTeams() {
-        Set<TeamDto> teams = restHelper.get(serviceBaseURL, "/team", new ParameterizedTypeReference<Set<TeamDto>>() {
+        Set<TeamDto> teams = restHelper.get(serviceBaseURL, "/team", new ParameterizedTypeReference<>() {
         });
         log.info("Got {} teams", teams.size(), value(EVENT, INFO_CLIENT_GET_TEAMS_SUCCESS));
         return teams;
     }
 
-    @Cacheable(value = "getAllTeams", unless = "#result == null")
     public Set<TeamDto> getAllTeams() {
-        Set<TeamDto> teams = restHelper.get(serviceBaseURL, "/team/all", new ParameterizedTypeReference<Set<TeamDto>>() {
+        Set<TeamDto> teams = restHelper.get(serviceBaseURL, "/team/all", new ParameterizedTypeReference<>() {
         });
         log.info("Got {} all teams", teams.size(), value(EVENT, INFO_CLIENT_GET_ALL_TEAMS_SUCCESS));
         return teams;
     }
 
-    @Cacheable(value = "getTeamsForUnit", unless = "#result == null")
     public Set<TeamDto> getTeamsForUnit(String unitUUID) {
-        Set<TeamDto> teams = restHelper.get(serviceBaseURL, String.format("/unit/%s/teams", unitUUID), new ParameterizedTypeReference<Set<TeamDto>>() {
+        Set<TeamDto> teams = restHelper.get(serviceBaseURL, String.format("/unit/%s/teams", unitUUID), new ParameterizedTypeReference<>() {
         });
         log.info("Got {} teams for unit", teams.size(), value(EVENT, INFO_CLIENT_GET_TEAMS_SUCCESS));
         return teams;
     }
 
-    @Cacheable(value = "getTeam", unless = "#result == null")
     public TeamDto getTeam(String uuid) {
-        TeamDto result = restHelper.get(serviceBaseURL, String.format("/team/%s", uuid), new ParameterizedTypeReference<TeamDto>() {
+        TeamDto result = restHelper.get(serviceBaseURL, String.format("/team/%s", uuid), new ParameterizedTypeReference<>() {
         });
         log.info("Got teamDto for team uuid {}, event {}", uuid, value(EVENT, INFO_CLIENT_GET_TEAM_SUCCESS));
         return result;
     }
 
-    @Cacheable(value = "getUnitByTeam", unless = "#result == null")
     public UnitDto getUnitByTeam(String uuid) {
-        UnitDto result = restHelper.get(serviceBaseURL, String.format("/team/%s/unit", uuid), new ParameterizedTypeReference<UnitDto>() {
+        UnitDto result = restHelper.get(serviceBaseURL, String.format("/team/%s/unit", uuid), new ParameterizedTypeReference<>() {
         });
         log.info("Got teamDto for team uuid {}, event {}", uuid, value(EVENT, INFO_CLIENT_GET_TEAM_SUCCESS));
         return result;
     }
 
-    @Cacheable(value = "getUnits", unless = "#result == null")
     public Set<UnitDto> getUnits() {
-        Set<UnitDto> units = restHelper.get(serviceBaseURL, "/unit", new ParameterizedTypeReference<Set<UnitDto>>() {
+        Set<UnitDto> units = restHelper.get(serviceBaseURL, "/unit", new ParameterizedTypeReference<>() {
         });
         log.info("Got {} teams", units.size(), value(EVENT, INFO_CLIENT_GET_UNITS_SUCCESS));
         return units;
     }
 
     public LinkedHashSet<String> getCaseExportFields(String caseType) {
-        LinkedHashSet<String> response = restHelper.get(serviceBaseURL, String.format("/schema/caseType/%s/reporting", caseType), new ParameterizedTypeReference<LinkedHashSet<String>>() {
+        LinkedHashSet<String> response = restHelper.get(serviceBaseURL, String.format("/schema/caseType/%s/reporting", caseType), new ParameterizedTypeReference<>() {
         });
         log.info("Got {} case reporting fields for CaseType {}", response.size(), caseType, value(EVENT, INFO_CLIENT_GET_EXPORT_FIELDS_SUCCESS));
         return response;
     }
 
     public List<ExportViewDto> getExportViews() {
-        List<ExportViewDto> views = restHelper.get(serviceBaseURL, "/export", new ParameterizedTypeReference<List<ExportViewDto>>() {
+        List<ExportViewDto> views = restHelper.get(serviceBaseURL, "/export", new ParameterizedTypeReference<>() {
         });
         log.info("Got {} export views, event: {}", views.size(), value(EVENT, INFO_CLIENT_GET_EXPORT_VIEWS_SUCCESS));
         return views;
     }
 
     public ExportViewDto getExportView(String code) {
-        ExportViewDto view = restHelper.get(serviceBaseURL, String.format("/export/%s", code), new ParameterizedTypeReference<ExportViewDto>() {
+        ExportViewDto view = restHelper.get(serviceBaseURL, String.format("/export/%s", code), new ParameterizedTypeReference<>() {
         });
 
         if (view != null) {
@@ -153,7 +145,7 @@ public class InfoClient {
 
     @Cacheable(value = "getEntitiesForList", unless = "#result == null")
     public Set<EntityDto> getEntitiesForList(String simpleName) {
-        Set<EntityDto> entities = restHelper.get(serviceBaseURL, String.format("/entity/list/%s", simpleName), new ParameterizedTypeReference<Set<EntityDto>>() {
+        Set<EntityDto> entities = restHelper.get(serviceBaseURL, String.format("/entity/list/%s", simpleName), new ParameterizedTypeReference<>() {
         });
         log.info("Got {} entities for list", entities.size(), value(EVENT, INFO_CLIENT_GET_TEAMS_SUCCESS));
         return entities;

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClientTest.java
@@ -69,19 +69,6 @@ public class InfoClientTest {
     }
 
     @Test
-    public void getUser() {
-        String userUUID = UUID.randomUUID().toString();
-        UserDto response = new UserDto("1", "user1", "Bill", "Smith", "bill.smith@email.com");
-        when(restHelper.get(eq(BASE_URL), eq("/user/" + userUUID), any(ParameterizedTypeReference.class))).thenReturn(response);
-        UserDto result = infoClient.getUser(userUUID);
-
-        assertThat(result).isEqualTo(response);
-        verify(restHelper).get(eq(BASE_URL), eq("/user/" + userUUID), any(ParameterizedTypeReference.class));
-
-        verifyNoMoreInteractions(restHelper);
-    }
-
-    @Test
     public void getSomuType() {
         SomuTypeDto response = new SomuTypeDto(UUID.randomUUID(), "caseType", "somuType", "{}", true);
         when(restHelper.get(eq(BASE_URL), eq("/somuType/caseType/somuType"), any(ParameterizedTypeReference.class))).thenReturn(response);


### PR DESCRIPTION
Currently as we use this class as a Service, it's underlying a 
singleton. In the initialise function which is called on every 
converted request, we clear out the conversion maps before 
re-populating. 
If however another request is using the data from this when 
converting, there is chance that the data is not present and 
therefore defaults to showing the uuid's instead of the converted 
data. This change therefore makes it so that the state of the 
conversion data does not get restored. Instead we now do an 
update to the data for every item.

To honour the boy scout principle, this change also removes 
redundant and poorly formed code.