### PR TITLE
Fix/hocs 3682 empty extract

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterFactory.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterFactory.java
@@ -10,6 +10,7 @@ import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -42,8 +43,8 @@ public class ExportDataConverterFactory {
                 .collect(Collectors.toMap(corr -> corr.getUuid().toString(), GetCorrespondentOutlineResponse::getFullname)));
 
         for (String listName : MPAM_CODE_MAPPING_LISTS) {
-            mpamCodeToName.putAll(infoClient.getEntitiesForList(listName).stream()
-                    .collect(Collectors.toMap(EntityDto::getSimpleName, entity -> entity.getData().getTitle())));
+            Set<EntityDto> entities = infoClient.getEntitiesForList(listName);
+            entities.forEach(e -> mpamCodeToName.put(e.getSimpleName(), e.getData().getTitle()));
         }
 
         return new ExportDataConverter(uuidToName, mpamCodeToName, caseworkClient);

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterFactoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterFactoryTest.java
@@ -7,6 +7,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClient;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.EntityDataDto;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.EntityDto;
 
 import java.util.*;
 
@@ -26,6 +28,7 @@ public class ExportDataConverterFactoryTest {
 
     @Before
     public void before() {
+
         when(infoClient.getUsers()).thenReturn(Set.of());
         when(infoClient.getAllTeams()).thenReturn(Set.of());
         when(infoClient.getUnits()).thenReturn(Set.of());
@@ -37,6 +40,17 @@ public class ExportDataConverterFactoryTest {
 
     @Test
     public void shouldGenerateExportDataConverter() {
+        ExportDataConverter exportDataConverter = converterFactory.getInstance();
+
+        assertThat(exportDataConverter).isNotNull();
+    }
+
+    @Test
+    public void shouldHandleDuplicateSimpleName() {
+        Set<EntityDto> entityDtos = Set.of(new EntityDto(1L, UUID.randomUUID(), "Name1", new EntityDataDto("title1"), UUID.randomUUID(), true),
+                new EntityDto(1L, UUID.randomUUID(), "Name1", new EntityDataDto("title1"), UUID.randomUUID(), true));
+        when(infoClient.getEntitiesForList("MPAM_ENQUIRY_SUBJECTS")).thenReturn(entityDtos);
+
         ExportDataConverter exportDataConverter = converterFactory.getInstance();
 
         assertThat(exportDataConverter).isNotNull();


### PR DESCRIPTION
Reinstate previous code to build mpamCodeToName map.
There can be duplicate simpleNames and they weren't being handled correctly.