### PR TITLE
HOCS-3696: use extractColumnLabel

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/dto/SomuTypeField.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/dto/SomuTypeField.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class SomuTypeField {
-    String component;
     String name;
-    String label;
+    String extractColumnLabel;
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
@@ -239,7 +239,7 @@ public class AuditExportServiceTest {
 
     @Test
     public void auditSomuExportShouldReturnCSVData() throws IOException {
-        SomuTypeDto somuTypeDto = new SomuTypeDto(UUID.fromString("655ddfa7-5ccf-4d9b-86fd-8cef5f61a318"), "MIN", "somuType", "{\"fields\":[{\"name\":\"field1\"},{\"name\":\"field2\"}]}", true);
+        SomuTypeDto somuTypeDto = new SomuTypeDto(UUID.fromString("655ddfa7-5ccf-4d9b-86fd-8cef5f61a318"), "MIN", "somuType", "{\"fields\":[{\"name\":\"field1\", \"extractColumnLabel\": \"Field 1\"},{\"name\":\"field2\", \"extractColumnLabel\": \"Field 2\"}]}", true);
         when(infoClient.getSomuType("MIN", "somuType")).thenReturn(somuTypeDto);
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), eq(ExportService.SOMU_TYPE_EVENTS), any())).thenReturn(getCaseDataWithSomuTypeAuditData().stream());
 
@@ -250,8 +250,8 @@ public class AuditExportServiceTest {
         assertThat(rows.size()).isEqualTo(1);
 
         CSVRecord row = rows.get(0);
-        assertThat(row.get("field1")).isEqualTo("value1");
-        assertThat(row.get("field2")).isEqualTo("value2");
+        assertThat(row.get("Field 1")).isEqualTo("value1");
+        assertThat(row.get("Field 2")).isEqualTo("value2");
     }
 
     @Test


### PR DESCRIPTION
The header for each of the contribution fields that we show now have a
extractColumnLabel that is used for the visual representation. This is
currently present due to the static-ness of the forms and that one field
has an id that does not represent what it is at present.