### PR TITLE
HOCS-4030: bring kube into project

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -100,20 +100,10 @@ environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
-  - name: clone kube repo
-    image: plugins/git
-    commands:
-      - git clone https://github.com/UKHomeOffice/kube-hocs-audit.git
-    when:
-      event:
-        - push
-        - promote
-
   - name: deploy to cs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - cd kube-hocs-audit
-      - ./deploy.sh
+      - ./kube/deploy.sh
     environment:
       ENVIRONMENT: cs-dev
       KUBE_TOKEN:
@@ -124,14 +114,11 @@ steps:
         - main
       event:
         - push
-    depends_on:
-      - clone kube repo
 
   - name: deploy to wcs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - cd kube-hocs-audit
-      - ./deploy.sh
+      - ./kube/deploy.sh
     environment:
       ENVIRONMENT: wcs-dev
       KUBE_TOKEN:
@@ -142,8 +129,6 @@ steps:
         - main
       event:
         - push
-    depends_on:
-      - clone kube repo
 
   - name: wait for docker
     image: docker
@@ -191,8 +176,7 @@ steps:
     commands:
       - source version.txt
       - echo $VERSION
-      - cd kube-hocs-audit
-      - ./deploy.sh
+      - ./kube/deploy.sh
     environment:
       ENVIRONMENT: cs-qa
       KUBE_TOKEN:
@@ -203,7 +187,6 @@ steps:
       target:
         - release
     depends_on:
-      - clone kube repo
       - generate & tag build
 
   - name: deploy to wcs-qa
@@ -211,8 +194,7 @@ steps:
     commands:
       - source version.txt
       - echo $VERSION
-      - cd kube-hocs-audit
-      - ./deploy.sh
+      - ./kube/deploy.sh
     environment:
       ENVIRONMENT: wcs-qa
       KUBE_TOKEN:
@@ -223,14 +205,12 @@ steps:
       target:
         - release
     depends_on:
-      - clone kube repo
       - generate & tag build
 
   - name: deploy to not prod
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - cd kube-hocs-audit
-      - ./deploy.sh
+      - ./kube/deploy.sh
     environment:
       ENVIRONMENT: ${DRONE_DEPLOY_TO}
       KUBE_TOKEN:
@@ -242,14 +222,11 @@ steps:
         exclude:
           - release
           - "*-prod"
-    depends_on:
-      - clone kube repo
 
   - name: deploy to prod
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - cd kube-hocs-audit
-      - ./deploy.sh
+      - ./kube/deploy.sh
     environment:
       ENVIRONMENT: ${DRONE_DEPLOY_TO}
       KUBE_TOKEN:
@@ -260,5 +237,3 @@ steps:
       target:
         include:
           - "*-prod"
-    depends_on:
-      - clone kube repo

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail # make bash quit if something weird happens
+
+export KUBE_NAMESPACE=${ENVIRONMENT}
+export KUBE_TOKEN=${KUBE_TOKEN}
+export VERSION=${VERSION}
+
+# passed to keycloak-gatekeeper and nginx for various proxy timeouts
+# the default is 60 seconds but audit has long-running queries
+export PROXY_TIMEOUT=${PROXY_TIMEOUT:-300}
+
+export DOMAIN="cs"
+if [ ${KUBE_NAMESPACE%-*} == "wcs" ]; then
+    export DOMAIN="wcs"
+fi
+
+if [[ ${KUBE_NAMESPACE} == *prod ]]
+then
+    export MIN_REPLICAS="2"
+    export MAX_REPLICAS="4"
+
+    export REFRESH_CRON="30 5 * * *"
+    export UPTIME_PERIOD="Mon-Sun 05:00-23:00 Europe/London"
+    
+    export CLUSTER_NAME="acp-prod"
+    export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
+else 
+    export MIN_REPLICAS="1"
+    export MAX_REPLICAS="2"
+
+    export REFRESH_CRON="0 9 * * 1-5"
+    export UPTIME_PERIOD="Mon-Fri 08:00-18:00 Europe/London"
+
+    export CLUSTER_NAME="acp-notprod"
+    export KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+fi
+
+if [[ "${ENVIRONMENT}" == "wcs-prod" ]] ; then
+    export DNS_PREFIX=www.${DOMAIN}
+    export KC_REALM=https://sso.digital.homeoffice.gov.uk/auth/realms/HOCS
+elif [[ "${ENVIRONMENT}" == "cs-prod" ]] ; then
+    export DNS_PREFIX=www.${DOMAIN}
+    export KC_REALM=https://sso.digital.homeoffice.gov.uk/auth/realms/hocs-prod
+else
+    export DNS_PREFIX=${DOMAIN}-notprod
+    export KC_REALM=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/hocs-notprod
+fi
+
+export DOMAIN_NAME=${DNS_PREFIX}.homeoffice.gov.uk	
+
+export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/${CLUSTER_NAME}.crt"
+
+echo
+echo "Deploying audit ${VERSION} to ${ENVIRONMENT}"
+echo "Keycloak realm: ${KC_REALM}"
+echo "Redirect URL: ${DOMAIN_NAME}"
+echo
+
+cd kd || exit 1
+
+kd --timeout 10m \
+    -f deployment.yaml \
+    -f service.yaml \
+    -f autoscale.yaml \
+    -f refreshDcuAggregatedCasesView.yaml

--- a/kube/kd/autoscale.yaml
+++ b/kube/kd/autoscale.yaml
@@ -1,0 +1,14 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: hocs-audit
+  name: hocs-audit
+spec:
+  maxReplicas: {{.MAX_REPLICAS}}
+  minReplicas: {{.MIN_REPLICAS}}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hocs-audit
+  targetCPUUtilizationPercentage: 70

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -1,0 +1,427 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hocs-audit
+  labels:
+    version: {{.VERSION}}
+  annotations:
+    downscaler/uptime: {{.UPTIME_PERIOD}}
+spec:
+  replicas: {{.MIN_REPLICAS}}
+  selector:
+    matchLabels:
+      name: hocs-audit
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: hocs-audit
+        role: hocs-backend
+        version: {{.VERSION}}
+    spec:
+      imagePullSecrets:
+        - name: registry-credentials
+      initContainers:
+        - name: truststore
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.9
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          args:
+            - --certs=/certs
+            - --command=/usr/bin/create-keystore.sh /certs/tls.pem /certs/tls-key.pem /etc/ssl/certs/acp-root.crt
+            - --domain=hocs-audit.${KUBE_NAMESPACE}.svc.cluster.local
+            - --domain=localhost
+            - --onetime=true
+          env:
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+            - name: keystore
+              mountPath: /etc/keystore
+            - name: bundle
+              mountPath: /etc/ssl/certs
+              readOnly: true
+          resources:
+            limits:
+              memory: 96Mi
+              cpu: 900m
+            requests:
+              memory: 96Mi
+              cpu: 300m
+
+        - name: db-initialise
+          image: docker.digital.homeoffice.gov.uk/hocs-db-provision:latest
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          env:
+            - name: DB_HOSTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: endpoint
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: db_name
+            - name: ROOT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: password
+            - name: DB_SCHEMA_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_schema
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_password
+            - name: DB_READONLY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-db-readonly
+                  key: rds_user
+            - name: DB_READONLY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-db-readonly
+                  key: rds_password
+          resources:
+            limits:
+              memory: 96Mi
+              cpu: 400m
+            requests:
+              memory: 96Mi
+              cpu: 100m
+
+      containers:
+        - name: keycloak-proxy
+          image: quay.digital.homeoffice.gov.uk/keycloak/keycloak-gatekeeper:8.0.2
+          securityContext:
+            runAsNonRoot: true
+          resources:
+            limits:
+              memory: 96Mi
+              cpu: 400m
+            requests:
+              memory: 96Mi
+              cpu: 100m
+          env:
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-frontend
+                  key: encryption_key
+          args:
+            - --config=/etc/secrets/data.yml
+            - --discovery-url={{.KC_REALM}}
+            - --openid-provider-proxy=http://hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local:31290
+            - --listen=127.0.0.1:8081
+            - --enable-logging=true
+            - --enable-json-logging=true
+            - --upstream-url=http://127.0.0.1:8080
+            - --upstream-response-header-timeout={{.PROXY_TIMEOUT}}s
+            - --upstream-expect-continue-timeout={{.PROXY_TIMEOUT}}s
+            - --upstream-keepalive-timeout={{.PROXY_TIMEOUT}}s
+            - --server-idle-timeout={{.PROXY_TIMEOUT}}s # default 120s
+            - --server-read-timeout={{.PROXY_TIMEOUT}}s
+            - --server-write-timeout={{.PROXY_TIMEOUT}}s
+            - --no-redirects=false
+            - --redirection-url=https://{{.DOMAIN_NAME}}
+            - --secure-cookie=true
+            - --http-only-cookie=true
+            - --revocation-url={{.KC_REALM}}/protocol/openid-connect/logout
+            - --enable-logout-redirect=true
+            - --enable-default-deny=true
+            - --resources=uri=/export/MIN*|roles=DCU_EXPORT_USER
+            - --resources=uri=/export/TRO*|roles=DCU_EXPORT_USER
+            - --resources=uri=/export/DTEN*|roles=DCU_EXPORT_USER
+            - --resources=uri=/export/WCS*|roles=WCS_EXPORT_USER
+            - --resources=uri=/export/MPAM*|roles=MPAM_EXPORT_USER
+            - --resources=uri=/export/MTS*|roles=MPAM_EXPORT_USER
+            - --resources=uri=/export/COMP*|roles=COMP_EXPORT_USER
+            - --resources=uri=/export/FOI*|roles=FOI_EXPORT_USER
+            - --resources=uri=/export/IEDET*|roles=IEDET_EXPORT_USER
+            - --resources=uri=/export/somu/FOI*|roles=FOI_EXPORT_USER
+            - --resources=uri=/export/somu/MPAM*|roles=MPAM_EXPORT_USER
+            - --resources=uri=/export/somu/COMP*|roles=COMP_EXPORT_USER
+            - --resources=uri=/export/topics*|roles=DCU_EXPORT_USER,FOI_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/teams*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/users*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/custom/*/refresh|methods=POST|white-listed=true
+            - --verbose
+            - --enable-refresh-tokens=true
+            - --encryption-key=$(ENCRYPTION_KEY)
+            - --cookie-domain={{.DOMAIN_NAME}}
+          ports:
+            - name: keycloak-http
+              containerPort: 8081
+          volumeMounts:
+            - mountPath: /etc/secrets
+              name: frontend-keycloak-secret
+              readOnly: true
+
+        - name: certs
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/cfssl-sidekick:v0.0.9
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          args:
+            - --certs=/certs
+            - --domain=hocs-audit.${KUBE_NAMESPACE}.svc.cluster.local
+            - --expiry=8760h
+            - --command=/usr/local/scripts/trigger_nginx_reload.sh
+          env:
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+            - name: bundle
+              mountPath: /etc/ssl/certs
+              readOnly: true
+          resources:
+            limits:
+              memory: 96Mi
+              cpu: 400m
+            requests:
+              memory: 96Mi
+              cpu: 100m
+
+        - name: proxy
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/nginx-proxy:v4.2.0
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          env:
+            - name: HTTP2
+              value: 'TRUE'
+            - name: PROXY_SERVICE_HOST_1
+              value: '127.0.0.1'
+            - name: PROXY_SERVICE_PORT_1
+              value: '8080'
+            - name: PROXY_SERVICE_HOST_2
+              value: '127.0.0.1'
+            - name: PROXY_SERVICE_PORT_2
+              value: '8081'
+            - name: LOCATIONS_CSV
+              value: '/, /export/'
+            - name: NAXSI_USE_DEFAULT_RULES
+              value: 'FALSE'
+            - name: ENABLE_UUID_PARAM
+              value: 'FALSE'
+            - name: HTTPS_REDIRECT
+              value: 'FALSE'
+            - name: BASIC_AUTH_1
+              value: /etc/nginx/authsecrets/htpasswd
+            - name: SERVER_CERT
+              value: /certs/tls.pem
+            - name: SERVER_KEY
+              value: /certs/tls-key.pem
+            - name: ADD_NGINX_SERVER_CFG
+              value: 'location = /reload { allow 127.0.0.1; deny all; content_by_lua_block { os.execute("touch /tmp/nginx-reload-triggered; /usr/local/openresty/nginx/sbin/nginx -s reload; touch /tmp/nginx-reload-complete;") } }'
+            - name: ADD_NGINX_HTTP_CFG
+              value: >
+                client_header_buffer_size 8k;
+                fastcgi_buffer_size 128k;
+                fastcgi_buffers 16 64k;
+                large_client_header_buffers 4 128k;
+                proxy_buffer_size 128k;
+                proxy_buffers 4 64k;
+                proxy_busy_buffers_size 128k;
+                proxy_connect_timeout {{.PROXY_TIMEOUT}};
+                proxy_read_timeout {{.PROXY_TIMEOUT}};
+                proxy_send_timeout {{.PROXY_TIMEOUT}};
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/nginx/secrets
+              readOnly: true
+            - name: auth-secrets
+              mountPath: /etc/nginx/authsecrets
+              readOnly: true
+          ports:
+            - name: https
+              containerPort: 10443
+          resources:
+            limits:
+              memory: 96Mi
+              cpu: 400m
+            requests:
+              memory: 96Mi
+              cpu: 100m
+
+        - name: hocs-audit
+          image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/hocs-audit:{{.VERSION}}
+          securityContext:
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - SETUID
+                - SETGID
+          envFrom:
+            - configMapRef:
+                name: hocs-queue-config
+          env:
+            - name: JAVA_OPTS
+              value: '-Xms512m -Xmx512m -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+            - name: JDK_TRUST_FILE
+              value: '/etc/keystore/truststore.jks'
+            - name: SERVER_PORT
+              value: '8080'
+            - name: SPRING_PROFILES_ACTIVE
+              value: 'sqs'
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: endpoint
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: port
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  key: db_name
+            - name: DB_SCHEMA_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_schema
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hocs-audit
+                  key: rds_password
+            - name: AUDIT_QUEUE_NAME
+              value: {{.KUBE_NAMESPACE}}-audit-sqs
+            - name: AWS_SQS_AUDIT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-audit-sqs
+                  key: sqs_queue_url
+            - name: AWS_SQS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-audit-sqs
+                  key: access_key_id
+            - name: AWS_SQS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.KUBE_NAMESPACE}}-audit-sqs
+                  key: secret_access_key
+            - name: HOCS_INFO_SERVICE
+              value: 'https://hocs-info-service.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+            - name: HOCS_CASE_SERVICE
+              value: 'https://hocs-casework.{{.KUBE_NAMESPACE}}.svc.cluster.local'
+            - name: HOCS_BASICAUTH
+              valueFrom:
+                secretKeyRef:
+                  name: ui-casework-creds
+                  key: plaintext
+          resources:
+            limits:
+              cpu: 1600m
+              memory: 768Mi
+            requests:
+              cpu: 350m
+              memory: 768Mi
+          ports:
+            - name: http
+              containerPort: 8080
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+              httpHeaders:
+                - name: X-probe
+                  value: kubelet
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+              httpHeaders:
+                - name: X-probe
+                  value: kubelet
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              httpHeaders:
+                - name: X-probe
+                  value: kubelet
+            periodSeconds: 2
+          volumeMounts:
+            - mountPath: /etc/keystore
+              name: keystore
+              readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "sh", "-c", "sleep 20" ]
+      volumes:
+        - name: keystore
+          emptyDir:
+            medium: "Memory"
+        - name: certs
+          emptyDir:
+            medium: "Memory"
+        - name: bundle
+          configMap:
+            name: bundle
+        - name: secrets
+          emptyDir:
+            medium: "Memory"
+        - name: auth-secrets
+          secret:
+            secretName: ui-casework-creds
+        - name: frontend-keycloak-secret
+          secret:
+            secretName: frontend-keycloak-secret

--- a/kube/kd/refreshDcuAggregatedCasesView.yaml
+++ b/kube/kd/refreshDcuAggregatedCasesView.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hocs-refresh-dcu-caseview
+spec:
+  schedule: {{.REFRESH_CRON}}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            name: hocs-refresh-dcu-caseview
+            role: hocs-backend
+        spec:
+          containers:
+            - name: hocs-refresh-dcu-caseview
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+              image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+              env:
+                - name: HOCS_BASICAUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: ui-casework-creds
+                      key: plaintext
+              command: ["/bin/sh", "-c"]
+              args:
+                - >
+                  http_status=$( curl -vk -X POST -u ${HOCS_BASICAUTH} -w '%{http_code}' -H 'User-Agent: Refresh DCU_AGGREGATED_CASES'
+                  https://hocs-audit.{{.KUBE_NAMESPACE}}.svc.cluster.local/admin/export/custom/DCU_AGGREGATED_CASES/refresh );
+                  if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi
+          restartPolicy: Never

--- a/kube/kd/service.yaml
+++ b/kube/kd/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: hocs-audit
+  name: hocs-audit
+spec:
+  ports:
+  - name: https
+    port: 443
+    targetPort: 10443
+  selector:
+    name: hocs-audit


### PR DESCRIPTION
To simplify releases and reduce the chance of configuration changes
unintentionally making its way into production this change brings the
kube repository into the service.