### PR TITLE
HOCS-4030: reintroduce kd path traversal

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -103,7 +103,8 @@ steps:
   - name: deploy to cs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - ./kube/deploy.sh
+      - cd kube
+      - ./deploy.sh
     environment:
       ENVIRONMENT: cs-dev
       KUBE_TOKEN:
@@ -118,7 +119,8 @@ steps:
   - name: deploy to wcs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - ./kube/deploy.sh
+      - cd kube
+      - ./deploy.sh
     environment:
       ENVIRONMENT: wcs-dev
       KUBE_TOKEN:
@@ -176,7 +178,8 @@ steps:
     commands:
       - source version.txt
       - echo $VERSION
-      - ./kube/deploy.sh
+      - cd kube
+      - ./deploy.sh
     environment:
       ENVIRONMENT: cs-qa
       KUBE_TOKEN:
@@ -194,7 +197,8 @@ steps:
     commands:
       - source version.txt
       - echo $VERSION
-      - ./kube/deploy.sh
+      - cd kube
+      - ./deploy.sh
     environment:
       ENVIRONMENT: wcs-qa
       KUBE_TOKEN:
@@ -210,7 +214,8 @@ steps:
   - name: deploy to not prod
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - ./kube/deploy.sh
+      - cd kube
+      - ./deploy.sh
     environment:
       ENVIRONMENT: ${DRONE_DEPLOY_TO}
       KUBE_TOKEN:
@@ -226,7 +231,8 @@ steps:
   - name: deploy to prod
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - ./kube/deploy.sh
+      - cd kube
+      - ./deploy.sh
     environment:
       ENVIRONMENT: ${DRONE_DEPLOY_TO}
       KUBE_TOKEN:


### PR DESCRIPTION
When running the deploy script as we cd into another directory this
fails in the pipeline if you run it from root of the project. This is
because the cd works from the current path you are in. This change
reverts this and adds a `cd kube`.