### PR TITLE
HOCS-4073: use spring context indexer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.22'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
-    annotationProcessor'org.springframework.boot:spring-boot-configuration-processor:2.5.5'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:2.5.5'
+    annotationProcessor "org.springframework:spring-context-indexer:5.3.12"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.5'
     testImplementation 'org.awaitility:awaitility:4.1.0'


### PR DESCRIPTION
While current class-pathing is fast, this change adds the spring context
 indexer that speeds this up by creating a list of candidates at
 compilation time.