### PR TITLE
HOCS-4073: improve actuator usage

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,15 @@ spring:
                 temp:
                     use_jdbc_metadata_defaults: false
 
+management:
+    endpoints:
+        enabled-by-default: false
+    endpoint:
+        health:
+            enabled: true
+            probes:
+                enabled: true
+
 aws:
     account:
         id: 123456789012


### PR DESCRIPTION
Currently, we are not using all the actuator endpoints effectively.
While we are not using them they are still being added to the
application context and cause a start-up penalty. This change disabled
all the endpoints (so we have to opt-in) and then re-enables the health
endpoints.