### PR TITLE
HOCS-4073: use docker multi-stage build

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-NAME=${NAME:-audit}
-
-JAR=$(find . -name ${NAME}*.jar|head -1)
-exec java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom -jar "${JAR}"
+exec java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom org.springframework.boot.loader.JarLauncher


### PR DESCRIPTION
At present, our current docker strategy is causing image size pollution
and inefficiencies. This is due to us not only using a fat jar strategy
instead of a layered jar, but also because our docker layers are not
cacheable. This change introduces a multi-stage docker build that splits
 out the build from the resultant image. In the second stage we then
 copy the minimum we require for running the build.