### PR TITLE
HOCS-4085: rework logstash

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="false">
 
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
     <springProperty scope="context" name="appName" source="info.app.name"/>
     <springProperty scope="context" name="appVersion" source="info.app.version"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -37,15 +37,7 @@
         <appender-ref ref="consoleAppender"/>
     </logger>
 
-    <logger name="org.apache.camel" additivity="false" level="WARN">
-        <appender-ref ref="consoleAppender"/>
-    </logger>
-
     <logger name="com.amazonaws" additivity="false" level="WARN">
-        <appender-ref ref="consoleAppender"/>
-    </logger>
-
-    <logger name="org.camunda" additivity="false" level="WARN">
         <appender-ref ref="consoleAppender"/>
     </logger>
 
@@ -66,6 +58,14 @@
     </logger>
 
     <logger name="com.zaxxer" additivity="false" level="WARN">
+        <appender-ref ref="consoleAppender"/>
+    </logger>
+
+    <logger name="org.xnio" additivity="false" level="WARN">
+        <appender-ref ref="consoleAppender"/>
+    </logger>
+
+    <logger name="org.jboss" additivity="false" level="WARN">
         <appender-ref ref="consoleAppender"/>
     </logger>
 


### PR DESCRIPTION
Use the defaults logback profile for the logger, at present we are using
the main one that instantiates its own console appender. This leads to
duplicated log messages being printed out to the console.

Presently, we have a number of loggers specified with logback that
aren't needed. These have been removed as they should not be present.
2 new loggers have been specified for xnio and jboss to only log
warnings out.