### PR TITLE
HOCS-4170 add BF and TO export user roles

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -172,6 +172,8 @@ spec:
             - --resources=uri=/export/somu/FOI*|roles=FOI_EXPORT_USER
             - --resources=uri=/export/somu/MPAM*|roles=MPAM_EXPORT_USER
             - --resources=uri=/export/somu/COMP*|roles=COMP_EXPORT_USER
+            - --resources=uri=/export/somu/TO*|roles=TO_EXPORT_USER
+            - --resources=uri=/export/somu/BF*|roles=BF_EXPORT_USER
             - --resources=uri=/export/topics*|roles=DCU_EXPORT_USER,FOI_EXPORT_USER|require-any-role=true
             - --resources=uri=/export/teams*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER|require-any-role=true
             - --resources=uri=/export/users*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER|require-any-role=true

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -166,6 +166,8 @@ spec:
             - --resources=uri=/export/MTS*|roles=MPAM_EXPORT_USER
             - --resources=uri=/export/COMP*|roles=COMP_EXPORT_USER
             - --resources=uri=/export/FOI*|roles=FOI_EXPORT_USER
+            - --resources=uri=/export/TO*|roles=TO_EXPORT_USER
+            - --resources=uri=/export/BF*|roles=BF_EXPORT_USER
             - --resources=uri=/export/IEDET*|roles=IEDET_EXPORT_USER
             - --resources=uri=/export/somu/FOI*|roles=FOI_EXPORT_USER
             - --resources=uri=/export/somu/MPAM*|roles=MPAM_EXPORT_USER


### PR DESCRIPTION
Added two export user roles for BF and TO. The export endpoints were previously freely accessible by any user.