### PR TITLE
HOCS-4215: implement interest export

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportType.java
@@ -7,6 +7,7 @@ public enum ExportType {
     CASE_NOTES,
     CORRESPONDENTS,
     EXTENSIONS,
+    INTERESTS,
     TOPICS,
     USER_TEAMS;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportType.java
@@ -1,12 +1,12 @@
 package uk.gov.digital.ho.hocs.audit.export;
 
 public enum ExportType {
+    ALLOCATIONS,
+    APPEALS,
     CASE_DATA,
     CASE_NOTES,
-    TOPICS,
     CORRESPONDENTS,
-    USER_TEAMS,
     EXTENSIONS,
-    ALLOCATIONS,
-    APPEALS;
+    TOPICS,
+    USER_TEAMS;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverter.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.audit.export.caseworkclient.dto.GetCaseReferenceResponse;
+import uk.gov.digital.ho.hocs.audit.utils.UuidStringChecker;
 
 import java.util.Map;
 import java.util.Set;
@@ -12,7 +13,6 @@ import java.util.Set;
 @Slf4j
 public class ExportDataConverter {
 
-    private static final String UUID_REGEX = "\\b[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b";
     private static final Set<String> MPAM_SHORT_CODES = Set.of("b5", "b6");
 
     private final CaseworkClient caseworkClient;
@@ -31,7 +31,7 @@ public class ExportDataConverter {
     public String[] convertData(String[] auditData, String caseShortCode) {
         for (int i = 0; i < auditData.length; i++){
             String fieldData = auditData[i];
-            if (isUUID(fieldData)) {
+            if (UuidStringChecker.isUUID(fieldData)) {
                 if (uuidToName.containsKey(fieldData)) {
                     auditData[i] = uuidToName.get(fieldData);
                 } else {
@@ -55,13 +55,6 @@ public class ExportDataConverter {
             }
         }
         return auditData;
-    }
-
-    boolean isUUID(String uuid) {
-        if (StringUtils.hasText(uuid)) {
-            return uuid.matches(UUID_REGEX);
-        }
-        return false;
     }
 
     private String sanitiseForCsv(String value) {

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverter.java
@@ -13,19 +13,19 @@ import java.util.Set;
 @Slf4j
 public class ExportDataConverter {
 
-    private static final Set<String> MPAM_SHORT_CODES = Set.of("b5", "b6");
+    private static final Set<String> CASE_TYPE_SHORT_CODES = Set.of("b5", "b6");
 
     private final CaseworkClient caseworkClient;
     private final Map<String, String> uuidToName;
-    private final Map<String, String> mpamCodeToName;
+    private final Map<String, String> entityListItemToName;
 
     private final String REFERENCE_NOT_FOUND = "REFERENCE NOT FOUND";
 
     ExportDataConverter
-            (Map<String, String> uuidToName, Map<String, String> mpamCodeToName, CaseworkClient caseworkClient) {
+            (Map<String, String> uuidToName, Map<String, String> entityListItemToName, CaseworkClient caseworkClient) {
         this.caseworkClient = caseworkClient;
         this.uuidToName = uuidToName;
-        this.mpamCodeToName = mpamCodeToName;
+        this.entityListItemToName = entityListItemToName;
     }
 
     public String[] convertData(String[] auditData, String caseShortCode) {
@@ -45,9 +45,9 @@ public class ExportDataConverter {
                     }
                 }
             } else {
-                if (MPAM_SHORT_CODES.contains(caseShortCode)) {
-                    if (mpamCodeToName.containsKey(fieldData)) {
-                        String displayValue = mpamCodeToName.get(fieldData);
+                if (CASE_TYPE_SHORT_CODES.contains(caseShortCode)) {
+                    if (entityListItemToName.containsKey(fieldData)) {
+                        String displayValue = entityListItemToName.get(fieldData);
                         String sanitizedDisplayValue = sanitiseForCsv(displayValue);
                         auditData[i] = sanitizedDisplayValue;
                     }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterFactory.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterFactory.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.audit.export.caseworkclient.dto.GetCorrespondentOutlineResponse;
-import uk.gov.digital.ho.hocs.audit.export.caseworkclient.dto.GetTopicResponse;
 import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.*;
 
@@ -17,7 +16,11 @@ import java.util.stream.Collectors;
 @Service
 public class ExportDataConverterFactory {
 
-    private static final String[] MPAM_CODE_MAPPING_LISTS = { "MPAM_ENQUIRY_SUBJECTS", "MPAM_ENQUIRY_REASONS_ALL", "MPAM_BUS_UNITS_ALL" };
+    private static final String[] CODE_MAPPING_ENTITY_LISTS = {
+            "MPAM_ENQUIRY_SUBJECTS",
+            "MPAM_ENQUIRY_REASONS_ALL",
+            "MPAM_BUS_UNITS_ALL",
+    };
 
     private final InfoClient infoClient;
     private final CaseworkClient caseworkClient;
@@ -29,7 +32,7 @@ public class ExportDataConverterFactory {
 
     public ExportDataConverter getInstance() {
         Map<String, String> uuidToName = new HashMap<>();
-        Map<String, String> mpamCodeToName = new HashMap<>();
+        Map<String, String> entityListItemToName = new HashMap<>();
 
         uuidToName.putAll(infoClient.getUsers().stream()
                 .collect(Collectors.toMap(UserDto::getId, UserDto::getUsername)));
@@ -46,11 +49,13 @@ public class ExportDataConverterFactory {
         uuidToName.putAll(infoClient.getCaseTypeActions().stream()
                 .collect(Collectors.toMap(action -> action.getUuid().toString(), CaseTypeActionDto::getActionLabel)));
 
-        for (String listName : MPAM_CODE_MAPPING_LISTS) {
+        for (String listName : CODE_MAPPING_ENTITY_LISTS) {
             Set<EntityDto> entities = infoClient.getEntitiesForList(listName);
-            entities.forEach(e -> mpamCodeToName.put(e.getSimpleName(), e.getData().getTitle()));
+            entities.forEach(e -> entityListItemToName.put(e.getSimpleName(), e.getData().getTitle()));
         }
 
-        return new ExportDataConverter(uuidToName, mpamCodeToName, caseworkClient);
+        return new ExportDataConverter(uuidToName, entityListItemToName, caseworkClient);
     }
+
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/dto/AuditPayload.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/dto/AuditPayload.java
@@ -191,4 +191,13 @@ public interface AuditPayload {
         private LocalDateTime created;
     }
 
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    class Interest {
+
+        private String partyType;
+        private String interestDetails;
+
+    }
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClientSupplier.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClientSupplier.java
@@ -1,0 +1,30 @@
+package uk.gov.digital.ho.hocs.audit.export.infoclient;
+
+import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.EntityDto;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.UserDto;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@Component
+public class InfoClientSupplier {
+
+    private final InfoClient infoClient;
+
+    public InfoClientSupplier(InfoClient infoClient) {
+        this.infoClient = infoClient;
+    }
+
+    public Supplier<Map<String,String>> getUsers() {
+        return () -> infoClient.getUsers().stream()
+                    .collect(Collectors.toMap(UserDto::getId, UserDto::getUsername));
+    }
+
+    public Supplier<Map<String, String>> getEntityList(String listName) {
+        return () -> infoClient.getEntitiesForList(listName).stream()
+                .collect(Collectors.toMap(EntityDto::getSimpleName, entity ->  entity.getData().getTitle()));
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/AbstractDataParser.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/AbstractDataParser.java
@@ -1,0 +1,97 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.StringUtils;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.auditdetails.model.AuditData;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.dto.GetCaseReferenceResponse;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClientSupplier;
+import uk.gov.digital.ho.hocs.audit.utils.UuidStringChecker;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public abstract class AbstractDataParser {
+
+    protected final ZonedDateTimeConverter zonedDateTimeConverter;
+    protected final ObjectMapper objectMapper;
+    protected final InfoClientSupplier infoClientSupplier;
+    protected final boolean convert;
+    private final CaseworkClient caseworkClient;
+
+    protected final Map<String, String> uuidToName;
+    protected final Map<String, String> entityListItemToName;
+
+    protected AbstractDataParser(InfoClientSupplier infoClientSupplier,
+                                 CaseworkClient caseworkClient,
+                                 ObjectMapper objectMapper,
+                                 ZonedDateTimeConverter zonedDateTimeConverter,
+                                 boolean convert) {
+        this.infoClientSupplier = infoClientSupplier;
+        this.convert = convert;
+        this.zonedDateTimeConverter = zonedDateTimeConverter;
+        this.objectMapper = objectMapper;
+        this.caseworkClient = caseworkClient;
+
+        uuidToName = new HashMap<>();
+        entityListItemToName = new HashMap<>();
+
+        if (convert) {
+            initialiseConversionValues(getUuidSuppliers(), getEntityLists());
+        }
+    }
+
+    private void initialiseConversionValues(Stream<Supplier<Map<String, String>>> uuidSuppliers,
+                                            List<String> entityLists) {
+        uuidToName.putAll(
+                uuidSuppliers
+                        .map(CompletableFuture::supplyAsync)
+                        .map(CompletableFuture::join)
+                        .collect(HashMap::new, Map::putAll, Map::putAll));
+
+        for (String listName: entityLists) {
+            entityListItemToName.putAll(infoClientSupplier.getEntityList(listName).get());
+        }
+    }
+
+
+    protected String convertValue(String value) {
+        if (!convert && value != null) {
+            return value;
+        }
+
+        if (UuidStringChecker.isUUID(value))  {
+            return uuidToName.getOrDefault(value, value);
+        }
+
+        return entityListItemToName.getOrDefault(value, value);
+    }
+
+    protected String convertCaseUuid(String value) {
+        if (!convert || !UuidStringChecker.isUUID(value)) {
+            return value;
+        }
+
+        GetCaseReferenceResponse caseReferenceResponse = caseworkClient.getCaseReference(value);
+
+        String referenceNotFound = "REFERENCE NOT FOUND";
+        if (StringUtils.hasText(caseReferenceResponse.getReference()) &&
+                // if the reference is not found, the uuid does not refer to a case, and can pass through
+                !caseReferenceResponse.getReference().equals(referenceNotFound)) {
+            return caseReferenceResponse.getReference();
+        }
+
+        return value;
+    }
+
+    public abstract String[] parsePayload(AuditData audit) throws JsonProcessingException;
+    protected abstract List<String> getEntityLists();
+    protected abstract Stream<Supplier<Map<String, String>>> getUuidSuppliers();
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/DataParserFactory.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/DataParserFactory.java
@@ -1,0 +1,43 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClientSupplier;
+import uk.gov.digital.ho.hocs.audit.export.parsers.interests.BfInterestDataParser;
+import uk.gov.digital.ho.hocs.audit.export.parsers.interests.FoiInterestDataParser;
+
+@Service
+public class DataParserFactory {
+
+    private final InfoClientSupplier infoClientSupplier;
+    private final CaseworkClient caseworkClient;
+    private final ObjectMapper objectMapper;
+
+    public DataParserFactory(InfoClientSupplier infoClientSupplier,
+                             CaseworkClient caseworkClient,
+                             ObjectMapper objectMapper) {
+        this.infoClientSupplier = infoClientSupplier;
+        this.caseworkClient = caseworkClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public AbstractDataParser getInterestInstance(String caseType, boolean convert, ZonedDateTimeConverter zonedDateTimeConverter)
+        throws IllegalArgumentException
+    {
+        switch (caseType) {
+            case "FOI": {
+                return new FoiInterestDataParser(infoClientSupplier, caseworkClient, objectMapper,
+                        zonedDateTimeConverter, convert);
+            }
+            case "BF": {
+                return new BfInterestDataParser(infoClientSupplier, caseworkClient, objectMapper,
+                        zonedDateTimeConverter, convert);
+            }
+            default:
+                throw new IllegalArgumentException(String.format("CaseType not supported: %s", caseType));
+        }
+    }
+    
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/AbstractInterestDataParser.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/AbstractInterestDataParser.java
@@ -1,0 +1,45 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers.interests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.auditdetails.model.AuditData;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.export.dto.AuditPayload;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClientSupplier;
+import uk.gov.digital.ho.hocs.audit.export.parsers.AbstractDataParser;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public abstract class AbstractInterestDataParser extends AbstractDataParser {
+
+    protected AbstractInterestDataParser(InfoClientSupplier infoClientSupplier, CaseworkClient caseworkClient,
+                                         ObjectMapper objectMapper, ZonedDateTimeConverter zonedDateTimeConverter,
+                                         boolean convert) {
+        super(infoClientSupplier, caseworkClient, objectMapper, zonedDateTimeConverter, convert);
+    }
+
+    @Override
+    protected Stream<Supplier<Map<String, String>>> getUuidSuppliers() {
+        return Stream.of(
+                infoClientSupplier.getUsers()
+        );
+    }
+
+    @Override
+    public String[] parsePayload(AuditData audit) throws JsonProcessingException {
+        AuditPayload.Interest interestData = objectMapper.readValue(audit.getAuditPayload(), AuditPayload.Interest.class);
+
+        return new String[] {
+                zonedDateTimeConverter.convert(audit.getAuditTimestamp()),
+                audit.getType(),
+                convertValue(audit.getUserID()),
+                convertCaseUuid(Objects.toString(audit.getCaseUUID(), "")),
+                convertValue(Objects.toString(interestData.getPartyType(), "")),
+                Objects.toString(interestData.getInterestDetails(), "")
+        };
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/BfInterestDataParser.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/BfInterestDataParser.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers.interests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClientSupplier;
+
+import java.util.List;
+
+public class BfInterestDataParser extends AbstractInterestDataParser {
+
+    public BfInterestDataParser(InfoClientSupplier infoClientSupplier, CaseworkClient caseworkClient,
+                                ObjectMapper objectMapper, ZonedDateTimeConverter zonedDateTimeConverter,
+                                boolean convert) {
+        super(infoClientSupplier, caseworkClient, objectMapper, zonedDateTimeConverter, convert);
+    }
+
+    @Override
+    public List<String> getEntityLists() {
+        return List.of("BF_INTERESTED_PARTIES");
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/FoiInterestDataParser.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/FoiInterestDataParser.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers.interests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClientSupplier;
+
+import java.util.List;
+
+public class FoiInterestDataParser extends AbstractInterestDataParser {
+
+    public FoiInterestDataParser(InfoClientSupplier infoClientSupplier, CaseworkClient caseworkClient,
+                                 ObjectMapper objectMapper, ZonedDateTimeConverter zonedDateTimeConverter,
+                                 boolean convert) {
+        super(infoClientSupplier, caseworkClient, objectMapper, zonedDateTimeConverter, convert);
+    }
+
+    @Override
+    protected List<String> getEntityLists() {
+        return List.of("FOI_INTERESTED_PARTIES");
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/utils/UuidStringChecker.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/utils/UuidStringChecker.java
@@ -1,0 +1,20 @@
+package uk.gov.digital.ho.hocs.audit.utils;
+
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+public class UuidStringChecker {
+
+    private static final String UUID_REGEX = "^[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}$";
+
+    private UuidStringChecker() {}
+
+    public static boolean isUUID(String uuid) {
+        if (StringUtils.hasText(uuid)) {
+            return Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE).matcher(uuid).matches();
+        }
+        return false;
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/CaseNoteExportTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/CaseNoteExportTest.java
@@ -13,6 +13,7 @@ import uk.gov.digital.ho.hocs.audit.auditdetails.repository.AuditRepository;
 import uk.gov.digital.ho.hocs.audit.export.converter.ExportDataConverterFactory;
 import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.CaseTypeDto;
+import uk.gov.digital.ho.hocs.audit.export.parsers.DataParserFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -49,6 +50,9 @@ public class CaseNoteExportTest {
     @Mock
     private MalformedDateConverter malformedDateConverter;
 
+    @Mock
+    private DataParserFactory dataParserFactory;
+
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
@@ -76,7 +80,7 @@ public class CaseNoteExportTest {
         when(auditRepository.findAuditDataByDateRangeAndEvents(any(), any(), any(), any())).thenReturn(Stream.of(auditData));
         when(infoClient.getCaseTypes()).thenReturn(Set.of(new CaseTypeDto("displayName", "a1", "type")));
         when(malformedDateConverter.correctDateFields(any())).then(returnsFirstArg());
-        return new ExportService(auditRepository, mapper, infoClient, exportDataConverterFactory, passThroughHeaderConverter, malformedDateConverter);
+        return new ExportService(auditRepository, mapper, infoClient, exportDataConverterFactory, passThroughHeaderConverter, malformedDateConverter, dataParserFactory);
     }
 
     private String createCaseNoteText(int length){

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/converter/ExportDataConverterTest.java
@@ -261,27 +261,6 @@ public class ExportDataConverterTest {
         assertThat(testResult[3]).isEqualTo(testData[3]);
     }
 
-    @Test
-    public void isUuid_TrueWithValidUuid() {
-        String uuid = UUID.randomUUID().toString();
-        assertThat(converter.isUUID(uuid)).isTrue();
-    }
-
-    @Test
-    public void isUuid_FalseWithInvalidUuidText() {
-        assertThat(converter.isUUID("Test")).isFalse();
-    }
-
-    @Test
-    public void isUuid_FalseWithNull() {
-        assertThat(converter.isUUID(null)).isFalse();
-    }
-
-    @Test
-    public void isUuid_FalseWithEmpty() {
-        assertThat(converter.isUUID("")).isFalse();
-    }
-
     private static Map<String, String> buildUuidToNameMap() {
         return new HashMap<>(
                 Map.ofEntries(

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClientSupplierTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/infoclient/InfoClientSupplierTest.java
@@ -1,0 +1,65 @@
+package uk.gov.digital.ho.hocs.audit.export.infoclient;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.EntityDataDto;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.EntityDto;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.dto.UserDto;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InfoClientSupplierTest {
+
+    @Mock
+    private InfoClient infoClient;
+
+    private final static UUID USER_UUID = UUID.randomUUID();
+
+    private InfoClientSupplier infoClientSupplier;
+
+    @Before
+    public void before() {
+        Mockito.when(infoClient.getEntitiesForList(any()))
+                .thenReturn(
+                        Set.of(new EntityDto(1L,
+                                UUID.randomUUID(),
+                                "TEST",
+                                new EntityDataDto("TEST_TITLE"),
+                                UUID.randomUUID(),
+                                true)));
+
+        Mockito.when(infoClient.getUsers())
+                .thenReturn(Set.of(new UserDto(USER_UUID.toString(), "TEST", "TEST_FIRST", "TEST_LAST", "TEST_EMAIL")));
+
+        infoClientSupplier = new InfoClientSupplier(infoClient);
+    }
+
+    @Test
+    public void shouldReturnEntitiesAsSupplier() {
+        var result = infoClientSupplier.getEntityList("TEST");
+        var resultMap = result.get();
+
+        Assert.assertEquals(1, resultMap.size());
+        Assert.assertTrue(resultMap.containsKey("TEST"));
+    }
+
+    @Test
+    public void shouldReturnUsers() {
+        var result = infoClientSupplier.getUsers();
+        var resultMap = result.get();
+
+        Assert.assertEquals(1, resultMap.size());
+        Assert.assertTrue(resultMap.containsKey(USER_UUID.toString()));
+    }
+
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/parsers/DataParserFactoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/parsers/DataParserFactoryTest.java
@@ -1,0 +1,41 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.export.parsers.interests.BfInterestDataParser;
+import uk.gov.digital.ho.hocs.audit.export.parsers.interests.FoiInterestDataParser;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class DataParserFactoryTest {
+
+    @Autowired
+    private DataParserFactory dataParserFactory;
+
+    @Test
+    public void shouldReturnFoiInterestParserWithCaseType() {
+        var result = dataParserFactory.getInterestInstance("FOI", false,
+                new ZonedDateTimeConverter(null, null));
+        Assert.assertEquals(result.getClass(), FoiInterestDataParser.class);
+    }
+
+    @Test
+    public void shouldReturnBfInterestParserWithCaseType() {
+        var result = dataParserFactory.getInterestInstance("BF", false,
+                new ZonedDateTimeConverter(null, null));
+        Assert.assertEquals(result.getClass(), BfInterestDataParser.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfCaseTypeNotInInterestAllowed() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> dataParserFactory.getInterestInstance("TEST", true,
+                        new ZonedDateTimeConverter(null, null)));
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/BfInterestDataParserTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/BfInterestDataParserTest.java
@@ -1,0 +1,104 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers.interests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.auditdetails.model.AuditData;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.dto.GetCaseReferenceResponse;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClientSupplier;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class BfInterestDataParserTest {
+
+    @MockBean
+    private InfoClientSupplier infoClientSupplier;
+    @MockBean
+    private CaseworkClient caseworkClient;
+
+    @SuppressWarnings("SpringJavaAutowiredMembersInspection")
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private ZonedDateTimeConverter zonedDateTimeConverter;
+
+    private final static UUID USER_UUID = UUID.randomUUID();
+    private final static UUID CASE_DATA_UUID = UUID.randomUUID();
+    private final static UUID STAGE_UUID = UUID.randomUUID();
+
+    @Before
+    public void before() {
+        this.zonedDateTimeConverter = new ZonedDateTimeConverter(null, null);
+
+        Mockito.when(infoClientSupplier.getUsers()).thenReturn(() -> Map.of(USER_UUID.toString(), "TEST_USER"));
+        Mockito.when(caseworkClient.getCaseReference(CASE_DATA_UUID.toString()))
+                .thenReturn(new GetCaseReferenceResponse(CASE_DATA_UUID, "TEST_CASE"));
+    }
+
+    @Test
+    public void shouldReturnUnconvertedValuesWhenFalse() throws JsonProcessingException {
+        String eventPayload =
+                "{\"uuid\": \"10000000-0000-0000-0000-000000000000\", \"caseType\": \"TEST_TYPE\", " +
+                        "\"eventType\": \"EXTERNAL_INTEREST_CREATED\", \"partyType\": \"PARTY_TYPE_1\"," +
+                        "\"caseDataUuid\": \"00000000-0000-0000-0000-000000000000\", \"interestDetails\": \"TEST_DETAILS\"}";
+
+        AuditData auditData = new AuditData(CASE_DATA_UUID, STAGE_UUID, UUID.randomUUID().toString(),
+                "TEST_SERVICE", eventPayload , "TEST_NAMESPACE",
+                LocalDateTime.of(2000,1,1,0,0), "TEST_TYPE",
+                USER_UUID.toString());
+
+        BfInterestDataParser bfInterestDataParser = new BfInterestDataParser(infoClientSupplier, caseworkClient, objectMapper,
+                zonedDateTimeConverter, false);
+
+        Assert.assertArrayEquals(new String[] { "2000-01-01T00:00:00.000000",
+                        "TEST_TYPE",
+                        USER_UUID.toString(),
+                        CASE_DATA_UUID.toString(),
+                        "PARTY_TYPE_1",
+                        "TEST_DETAILS" },
+                bfInterestDataParser.parsePayload(auditData));
+    }
+
+    @Test
+    public void shouldReturnConvertedValuesWhenTrue() throws JsonProcessingException {
+        String eventPayload =
+                "{\"uuid\": \"10000000-0000-0000-0000-000000000000\", \"caseType\": \"TEST_TYPE\", " +
+                        "\"eventType\": \"EXTERNAL_INTEREST_CREATED\", \"partyType\": \"PARTY_TYPE_1\"," +
+                        "\"caseDataUuid\": \"00000000-0000-0000-0000-000000000000\", \"interestDetails\": \"TEST_DETAILS\"}";
+
+        AuditData auditData = new AuditData(CASE_DATA_UUID, STAGE_UUID, UUID.randomUUID().toString(),
+                "TEST_SERVICE", eventPayload , "TEST_NAMESPACE",
+                LocalDateTime.of(2000,1,1,0,0), "TEST_TYPE",
+                USER_UUID.toString());
+
+        Mockito.when(infoClientSupplier.getEntityList(any())).thenReturn(() -> Map.of("PARTY_TYPE_1", "TEST_PARTY"));
+
+        BfInterestDataParser bfInterestDataParser = new BfInterestDataParser(infoClientSupplier, caseworkClient, objectMapper,
+                zonedDateTimeConverter, true);
+
+        Assert.assertArrayEquals(new String[] { "2000-01-01T00:00:00.000000",
+                        "TEST_TYPE",
+                        "TEST_USER",
+                        "TEST_CASE",
+                        "TEST_PARTY",
+                        "TEST_DETAILS" },
+                bfInterestDataParser.parsePayload(auditData));
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/FoiInterestDataParserTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/parsers/interests/FoiInterestDataParserTest.java
@@ -1,0 +1,104 @@
+package uk.gov.digital.ho.hocs.audit.export.parsers.interests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.audit.application.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.auditdetails.model.AuditData;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.export.caseworkclient.dto.GetCaseReferenceResponse;
+import uk.gov.digital.ho.hocs.audit.export.infoclient.InfoClientSupplier;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class FoiInterestDataParserTest {
+
+    @MockBean
+    private InfoClientSupplier infoClientSupplier;
+    @MockBean
+    private CaseworkClient caseworkClient;
+
+    @SuppressWarnings("SpringJavaAutowiredMembersInspection")
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private ZonedDateTimeConverter zonedDateTimeConverter;
+
+    private final static UUID USER_UUID = UUID.randomUUID();
+    private final static UUID CASE_DATA_UUID = UUID.randomUUID();
+    private final static UUID STAGE_UUID = UUID.randomUUID();
+
+    @Before
+    public void before() {
+        this.zonedDateTimeConverter = new ZonedDateTimeConverter(null, null);
+
+        Mockito.when(infoClientSupplier.getUsers()).thenReturn(() -> Map.of(USER_UUID.toString(), "TEST_USER"));
+        Mockito.when(caseworkClient.getCaseReference(CASE_DATA_UUID.toString()))
+                .thenReturn(new GetCaseReferenceResponse(CASE_DATA_UUID, "TEST_CASE"));
+    }
+
+    @Test
+    public void shouldReturnUnconvertedValuesWhenFalse() throws JsonProcessingException {
+        String eventPayload =
+                "{\"uuid\": \"10000000-0000-0000-0000-000000000000\", \"caseType\": \"TEST_TYPE\", " +
+                        "\"eventType\": \"EXTERNAL_INTEREST_CREATED\", \"partyType\": \"PARTY_TYPE_1\"," +
+                        "\"caseDataUuid\": \"00000000-0000-0000-0000-000000000000\", \"interestDetails\": \"TEST_DETAILS\"}";
+
+        AuditData auditData = new AuditData(CASE_DATA_UUID, STAGE_UUID, UUID.randomUUID().toString(),
+                "TEST_SERVICE", eventPayload , "TEST_NAMESPACE",
+                LocalDateTime.of(2000,1,1,0,0), "TEST_TYPE",
+                USER_UUID.toString());
+
+        FoiInterestDataParser foiInterestDataParser = new FoiInterestDataParser(infoClientSupplier, caseworkClient, objectMapper,
+                zonedDateTimeConverter, false);
+
+        Assert.assertArrayEquals(new String[] { "2000-01-01T00:00:00.000000",
+                        "TEST_TYPE",
+                        USER_UUID.toString(),
+                        CASE_DATA_UUID.toString(),
+                        "PARTY_TYPE_1",
+                        "TEST_DETAILS" },
+                foiInterestDataParser.parsePayload(auditData));
+    }
+
+    @Test
+    public void shouldReturnConvertedValuesWhenTrue() throws JsonProcessingException {
+        String eventPayload =
+                "{\"uuid\": \"10000000-0000-0000-0000-000000000000\", \"caseType\": \"TEST_TYPE\", " +
+                        "\"eventType\": \"EXTERNAL_INTEREST_CREATED\", \"partyType\": \"PARTY_TYPE_1\"," +
+                        "\"caseDataUuid\": \"00000000-0000-0000-0000-000000000000\", \"interestDetails\": \"TEST_DETAILS\"}";
+
+        AuditData auditData = new AuditData(CASE_DATA_UUID, STAGE_UUID, UUID.randomUUID().toString(),
+                "TEST_SERVICE", eventPayload , "TEST_NAMESPACE",
+                LocalDateTime.of(2000,1,1,0,0), "TEST_TYPE",
+                USER_UUID.toString());
+
+        Mockito.when(infoClientSupplier.getEntityList(any())).thenReturn(() -> Map.of("PARTY_TYPE_1", "TEST_PARTY"));
+
+        FoiInterestDataParser foiInterestDataParser = new FoiInterestDataParser(infoClientSupplier, caseworkClient, objectMapper,
+                zonedDateTimeConverter, true);
+
+        Assert.assertArrayEquals(new String[] { "2000-01-01T00:00:00.000000",
+                        "TEST_TYPE",
+                        "TEST_USER",
+                        "TEST_CASE",
+                        "TEST_PARTY",
+                        "TEST_DETAILS" },
+                foiInterestDataParser.parsePayload(auditData));
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/utils/UuidStringCheckerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/utils/UuidStringCheckerTest.java
@@ -1,0 +1,36 @@
+package uk.gov.digital.ho.hocs.audit.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Locale;
+import java.util.UUID;
+
+public class UuidStringCheckerTest {
+
+    @Test
+    public void shouldReturnTrueWithUppercaseUuidString() {
+        Assert.assertTrue(UuidStringChecker.isUUID(UUID.randomUUID().toString().toUpperCase(Locale.ROOT)));
+    }
+
+    @Test
+    public void shouldReturnTrueWithLowercaseUuidString() {
+        Assert.assertTrue(UuidStringChecker.isUUID(UUID.randomUUID().toString().toLowerCase(Locale.ROOT)));
+    }
+
+    @Test
+    public void shouldReturnFalseWithNullString() {
+        Assert.assertFalse(UuidStringChecker.isUUID(null));
+    }
+
+    @Test
+    public void shouldReturnFalseWithEmptyString() {
+        Assert.assertFalse(UuidStringChecker.isUUID(""));
+    }
+
+    @Test
+    public void shouldReturnFalseWithInvalidString() {
+        Assert.assertFalse(UuidStringChecker.isUUID("TEST"));
+    }
+
+}


### PR DESCRIPTION
This change implements the CSV writing for interest actions utilising
the new data parser.

To support this new data parser classes have been added, this supports
the simplification of parsing and pritning the data. Typically when users 
run convert on an audit request we spin up a new export data converter
that populates with data that isn't used. This is then ran against all data
rows and columns - and where it matches a UUID not in the mapping
sends a request to casework as it assumes its a case reference. For all 
exports (except CASE_DATA) we know the values that we want to convert
and the values required for the conversion. This data parser acts as the
total send of truth for row conversions, supporting only conversion on 
fields required. 

This change also contains refactoring to clarify variable names and
extract functionality.