### PR TITLE
HOCS-4697 Removes BF2 export role

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -168,17 +168,15 @@ spec:
             - --resources=uri=/export/FOI*|roles=FOI_EXPORT_USER
             - --resources=uri=/export/TO*|roles=TO_EXPORT_USER
             - --resources=uri=/export/BF*|roles=BF_EXPORT_USER
-            - --resources=uri=/export/BF2*|roles=BF2_EXPORT_USER
             - --resources=uri=/export/IEDET*|roles=IEDET_EXPORT_USER
             - --resources=uri=/export/somu/FOI*|roles=FOI_EXPORT_USER
             - --resources=uri=/export/somu/MPAM*|roles=MPAM_EXPORT_USER
             - --resources=uri=/export/somu/COMP*|roles=COMP_EXPORT_USER
             - --resources=uri=/export/somu/TO*|roles=TO_EXPORT_USER
             - --resources=uri=/export/somu/BF*|roles=BF_EXPORT_USER
-            - --resources=uri=/export/somu/BF2*|roles=BF2_EXPORT_USER
             - --resources=uri=/export/topics*|roles=DCU_EXPORT_USER,FOI_EXPORT_USER|require-any-role=true
-            - --resources=uri=/export/teams*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER,BF_EXPORT_USER,BF2_EXPORT_USER|require-any-role=true
-            - --resources=uri=/export/users*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER,BF_EXPORT_USER,BF2_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/teams*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER,BF_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/users*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER,COMP_EXPORT_USER,FOI_EXPORT_USER,IEDET_EXPORT_USER,BF_EXPORT_USER|require-any-role=true
             - --resources=uri=/export/custom/*/refresh|methods=POST|white-listed=true
             - --verbose
             - --enable-refresh-tokens=true


### PR DESCRIPTION
BF_EXPORT_USER should cover for BF and BF2, so we can remove the BF2 role