### PR TITLE
HOCS-4808: support tagging on support branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -152,6 +152,7 @@ trigger:
     - tag
   branch:
     - main
+    - support/*
 
 services:
   - name: postgres
@@ -184,7 +185,7 @@ steps:
     depends_on:
       - setup localstack
 
-  - name: build & push latest
+  - name: build & push tag main
     image: plugins/docker
     settings:
       registry: quay.io
@@ -199,6 +200,27 @@ steps:
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
     depends_on:
       - test project
+    when:
+      branch:
+        - main
+
+  - name: build & push tag
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-audit
+      tags:
+        - ${DRONE_TAG}
+        - ${DRONE_COMMIT_SHA}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - test project
+    when:
+      branch:
+        - support/*
 
 ---
 kind: pipeline


### PR DESCRIPTION
To support hotfixing this change allows the for a build and tag step to
be run on support branches aswell.