### PR TITLE
HOCS-4863: update semver tag action release version

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           labels: minor,major,patch,skip-release
           mode: singular
-      - uses: UKHomeOffice/semver-tag-action@v2.0.0
+      - uses: UKHomeOffice/semver-tag-action@v2.0.2
         if: contains(steps.label.outputs.matchedLabels, 'skip-release') == false
         with:
           increment: ${{ steps.label.outputs.matchedLabels }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           labels: minor,major,patch,skip-release
           mode: singular
-      - uses: UKHomeOffice/semver-tag-action@v2.0.0
+      - uses: UKHomeOffice/semver-tag-action@v2.0.2
         if: contains(steps.label.outputs.matchedLabels, 'skip-release') == false
         with:
           increment: ${{ steps.label.outputs.matchedLabels }}


### PR DESCRIPTION
Update semver tag action version to the latest release.