### PR TITLE
HOCS-4940: introduce new latest table

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepository.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 
 
 @Repository
-public interface AuditRepository extends PagingAndSortingRepository<AuditEvent, String>, AuditRepositoryCustom {
+public interface AuditRepository extends PagingAndSortingRepository<AuditEvent, String>, AuditRepositoryCustom, AuditRepositoryLatestEvents {
 
 
     AuditEvent findAuditDataByUuid(UUID uuid);

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryLatestEvents.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryLatestEvents.java
@@ -1,0 +1,16 @@
+package uk.gov.digital.ho.hocs.audit.auditdetails.repository;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import uk.gov.digital.ho.hocs.audit.auditdetails.model.AuditEvent;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+@Repository
+public interface AuditRepositoryLatestEvents {
+
+    @Query(value = "SELECT a.* FROM audit_event_latest_events a WHERE a.audit_timestamp >= ?1 AND a.type in ?2 AND a.case_type = ?3 AND a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC;", nativeQuery = true)
+    Stream<AuditEvent> findAuditEventLatestEventsAfterDate(LocalDateTime of, String[] events, String caseType);
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/DataExportResource.java
@@ -22,10 +22,12 @@ public class DataExportResource {
         this.customExportService = customExportService;
     }
 
-    @GetMapping(value = "/export/{caseType}", params = {"fromDate", "toDate", "exportType"})
+    @GetMapping(value = "/export/{caseType}", params = {"fromDate", "exportType"})
     public @ResponseBody
-    void getDataExport(@RequestParam("fromDate") LocalDate fromDate, @RequestParam("toDate") LocalDate toDate,
-                       @PathVariable("caseType") String caseType, @RequestParam("exportType") ExportType exportType,
+    void getDataExport(@RequestParam("fromDate") LocalDate fromDate,
+                       @RequestParam(name = "toDate", defaultValue = "#{T(java.time.LocalDate).now()}") LocalDate toDate,
+                       @PathVariable("caseType") String caseType,
+                       @RequestParam("exportType") ExportType exportType,
                        @RequestParam(name = "convert", defaultValue = "false") boolean convert,
                        @RequestParam(name = "convertHeader", defaultValue = "false") boolean convertHeader,
                        @RequestParam(name = "timestampFormat", required = false) String timestampFormat,
@@ -43,10 +45,10 @@ public class DataExportResource {
         }
     }
 
-    @GetMapping(value = "/export/somu/{caseType}", params = {"fromDate", "toDate", "somuType"})
+    @GetMapping(value = "/export/somu/{caseType}", params = {"fromDate", "somuType"})
     public @ResponseBody
     void getSomuExport(@RequestParam("fromDate") LocalDate fromDate,
-                       @RequestParam("toDate") LocalDate toDate,
+                       @RequestParam(value = "toDate", defaultValue = "#{T(java.time.LocalDate).now()}") LocalDate toDate,
                        @PathVariable("caseType") String caseType,
                        @RequestParam("somuType") String somuType,
                        @RequestParam(name = "convert", defaultValue = "false") boolean convert,

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
@@ -75,7 +75,8 @@ public class ExportService {
 
         OutputStream buffer = new BufferedOutputStream(output);
         OutputStreamWriter outputWriter = new OutputStreamWriter(buffer, StandardCharsets.UTF_8);
-        String caseTypeCode = infoClient.getCaseTypes().stream().filter(e -> e.getType().equals(caseType)).findFirst().get().getShortCode();
+        String caseTypeCode = infoClient.getCaseTypes().stream().filter(e -> e.getType().equals(caseType)).findFirst().
+                get().getShortCode();
         switch (exportType) {
             case CASE_DATA:
                 caseDataExport(from, to, outputWriter, caseTypeCode, caseType, convert, convertHeader, zonedDateTimeConverter);
@@ -118,16 +119,16 @@ public class ExportService {
     }
 
     private Stream<AuditEvent> getAuditDataStream(boolean lastAudit, String[] events, LocalDate from, LocalDate to, String caseTypeCode){
-        if(lastAudit){
+        LocalDate peggedTo = to.isAfter(LocalDate.now()) ? LocalDate.now() : to;
+
+        if (lastAudit) {
             return auditRepository.findLastAuditDataByDateRangeAndEvents(LocalDateTime.of(
-                    from, LocalTime.MIN), LocalDateTime.of(to, LocalTime.MAX),
+                            from, LocalTime.MIN), LocalDateTime.of(peggedTo, LocalTime.MAX),
                     events, caseTypeCode);
         }
-        else{
-            return auditRepository.findAuditDataByDateRangeAndEvents(LocalDateTime.of(
-                from, LocalTime.MIN), LocalDateTime.of(to, LocalTime.MAX),
+        return auditRepository.findAuditDataByDateRangeAndEvents(LocalDateTime.of(
+                from, LocalTime.MIN), LocalDateTime.of(peggedTo, LocalTime.MAX),
                 events, caseTypeCode);
-        }
     }
 
     private void genericParseAndPrint(boolean lastAuditDataStream, String[] events, ExportType exportType, LocalDate from, LocalDate to, OutputStreamWriter outputWriter, String caseTypeCode, boolean convert, boolean convertHeader, final ZonedDateTimeConverter zonedDateTimeConverter, LinkedHashSet<String> caseDataHeaders, List<String> headers) throws IOException{

--- a/src/main/resources/db/migration/postgresql/V1_9__CREATE_LATEST_TYPE_TABLE.sql
+++ b/src/main/resources/db/migration/postgresql/V1_9__CREATE_LATEST_TYPE_TABLE.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS audit_event_latest_events
+(
+    id                     BIGSERIAL,
+    uuid                   UUID        NOT NULL,
+    case_uuid              UUID,
+    stage_uuid             UUID,
+    correlation_id         TEXT        NOT NULL,
+    raising_service        TEXT        NOT NULL,
+    audit_payload          JSONB,
+    namespace              TEXT        NOT NULL,
+    audit_timestamp        TIMESTAMP   NOT NULL,
+    type                   TEXT        NOT NULL,
+    user_id                TEXT        NOT NULL,
+    case_type              TEXT,
+    deleted                BOOLEAN    NOT NULL DEFAULT FALSE,
+
+    PRIMARY KEY (uuid),
+    CONSTRAINT audit_event_latest_events_audit_timestamp_type_uuid UNIQUE (audit_timestamp, case_type, type, case_uuid),
+    CONSTRAINT audit_event_latest_events_case_uuid_type UNIQUE (case_uuid, type)
+);


### PR DESCRIPTION
Introduce a new partitioned table that holds the latest value for
specified types. These partitions mimic the existing partitions on the
`audit_event` table.

This also removes the `toDate` from the required parameters and defaults this
to todays date if not specified. If a user specifies a future date -
this is pegged to todays date within the ExportService to save the
database engine from using non-used dates in its planning time.