### PR TITLE
HOCS-4940: use latest table

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/export/ExportService.java
@@ -122,6 +122,10 @@ public class ExportService {
         LocalDate peggedTo = to.isAfter(LocalDate.now()) ? LocalDate.now() : to;
 
         if (lastAudit) {
+            if (peggedTo.equals(LocalDate.now())) {
+                return auditRepository.findAuditEventLatestEventsAfterDate(LocalDateTime.of(
+                        from, LocalTime.MIN), events, caseTypeCode);
+            }
             return auditRepository.findLastAuditDataByDateRangeAndEvents(LocalDateTime.of(
                             from, LocalTime.MIN), LocalDateTime.of(peggedTo, LocalTime.MAX),
                     events, caseTypeCode);

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/export/AuditExportServiceTest.java
@@ -72,6 +72,7 @@ public class AuditExportServiceTest {
     private Set<CaseTypeDto> caseTypes = new HashSet<CaseTypeDto>() {{
         add(new CaseTypeDto("DCU Ministerial", "a1", "MIN"));
         add(new CaseTypeDto("TEST", "a1", "BF"));
+        add(new CaseTypeDto("TEST", "a1", "TEST"));
     }};
     private LocalDateTime from = LocalDateTime.of(2019, 1, 1, 0, 0);
     private LocalDateTime to = LocalDateTime.of(LocalDate.of(2019, 6, 1), LocalTime.MAX);
@@ -194,6 +195,17 @@ public class AuditExportServiceTest {
 
         verify(auditRepository, times(1)).findLastAuditDataByDateRangeAndEvents(from, to, ExportService.CASE_DATA_EVENTS, "a1");
         verify(exportDataConverter, times(getCaseDataAuditData().size())).convertData(any(), any());
+    }
+
+    @Test
+    public void caseDataExportTodaysDateHitsLatestTable() throws IOException {
+        when(infoClient.getCaseExportFields("TEST")).thenReturn(fields);
+        when(auditRepository.findAuditEventLatestEventsAfterDate(any(), eq(ExportService.CASE_DATA_EVENTS), any())).thenReturn(getCaseDataAuditData().stream());
+
+        OutputStream outputStream = new ByteArrayOutputStream();
+        exportService.auditExport(from.toLocalDate(), LocalDate.now(), outputStream, "TEST", ExportType.CASE_DATA, false, false, null, null);
+
+        verify(auditRepository, times(1)).findAuditEventLatestEventsAfterDate(from, ExportService.CASE_DATA_EVENTS, "a1");
     }
 
     @Test


### PR DESCRIPTION
Use the audit event latest table for audit events that require only the
lastest type rows. This only runs if the to date is the current date to
ensure valid data. `toDate` in the past still use the old solution.