### PR TITLE
HOCS-4921: ~half the execution time for audit_event_latest_events query

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryLatestEvents.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/auditdetails/repository/AuditRepositoryLatestEvents.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 @Repository
 public interface AuditRepositoryLatestEvents {
 
-    @Query(value = "SELECT a.* FROM audit_event_latest_events a WHERE a.audit_timestamp >= ?1 AND a.type in ?2 AND a.case_type = ?3 AND a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC;", nativeQuery = true)
+    @Query(value = "SELECT a.* FROM audit_event_latest_events a WHERE a.audit_timestamp between ?1 and 'tomorrow' AND a.type in ?2 AND a.case_type = ?3 AND a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC", nativeQuery = true)
     Stream<AuditEvent> findAuditEventLatestEventsAfterDate(LocalDateTime of, String[] events, String caseType);
 
 }


### PR DESCRIPTION
```
hocsprodaudit=> explain analyze  SELECT a.* FROM audit_event_latest_events a WHERE a.audit_timestamp >= '2022-01-01' AND a.type in ('CASE_CREATED', 'CASE_COMPLETED', 'CASE_UPDATED') AND a.case_type = 'b6' AND a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC;
                                                                                                    QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=65803.06..66064.03 rows=104387 width=752) (actual time=262.438..273.048 rows=91618 loops=1)
   Sort Key: case_uuid, type, audit_timestamp DESC
   Sort Method: quicksort  Memory: 115663kB
   ->  Seq Scan on audit_event_latest_events a  (cost=0.00..57101.58 rows=104387 width=752) (actual time=0.010..159.248 rows=91618 loops=1)
         Filter: ((NOT deleted) AND (audit_timestamp >= '2022-01-01 00:00:00'::timestamp without time zone) AND (case_type = 'b6'::text) AND (type = ANY ('{CASE_CREATED,CASE_COMPLETED,CASE_UPDATED}'::text[])))
         Rows Removed by Filter: 387024
 Planning Time: 0.121 ms
 Execution Time: 287.509 ms
(8 rows)

hocsprodaudit=> explain analyze  SELECT a.* FROM audit_event_latest_events a WHERE a.audit_timestamp between '2022-01-01' and 'tomorrow' AND a.type in ('CASE_CREATED', 'CASE_COMPLETED', 'CASE_UPDATED') AND a.case_type = 'b6' AND a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC;
                                                                                                                                             QUERY PLAN                                                                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Merge  (cost=56794.11..66943.65 rows=86990 width=752) (actual time=90.861..137.824 rows=91618 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Sort  (cost=55794.08..55902.82 rows=43495 width=752) (actual time=88.336..91.879 rows=30539 loops=3)
         Sort Key: case_uuid, type, audit_timestamp DESC
         Sort Method: quicksort  Memory: 39711kB
         Worker 0:  Sort Method: quicksort  Memory: 37266kB
         Worker 1:  Sort Method: quicksort  Memory: 37919kB
         ->  Parallel Seq Scan on audit_event_latest_events a  (cost=0.00..52443.11 rows=43495 width=752) (actual time=0.008..56.134 rows=30539 loops=3)
               Filter: ((NOT deleted) AND (audit_timestamp >= '2022-01-01 00:00:00'::timestamp without time zone) AND (audit_timestamp <= '2022-04-23 00:00:00'::timestamp without time zone) AND (case_type = 'b6'::text) AND (type = ANY ('{CASE_CREATED,CASE_COMPLETED,CASE_UPDATED}'::text[])))
               Rows Removed by Filter: 129008
 Planning Time: 0.188 ms
 Execution Time: 145.505 ms
(13 rows)
```