### PR TITLE
HOCS-5038: improve latest stream handling

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/repository/AuditRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/repository/AuditRepository.java
@@ -57,8 +57,13 @@ public interface AuditRepository extends JpaRepository<AuditEvent, String>, Audi
             @QueryHint(name = HINT_CACHEABLE, value = "false"),
             @QueryHint(name = READ_ONLY, value = "true")
     })
-    @Query(value = "SELECT a.* FROM audit_event_latest_events a WHERE a.audit_timestamp between ?1 and 'tomorrow' AND a.type in ?2 AND a.case_type = ?3 AND a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC", nativeQuery = true)
-    Stream<AuditEvent> findAuditEventLatestEventsAfterDate(LocalDateTime of, String[] events, String caseType);
+    @Query(value = "SELECT a.* FROM audit_event_latest_events a " +
+            "WHERE a.audit_timestamp BETWEEN ?1 AND ?2 AND " +
+            "a.type IN ?3 AND " +
+            "a.case_type = ?4 AND " +
+            "a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC " +
+            "FOR UPDATE", nativeQuery = true)
+    Stream<AuditEvent> findAuditEventLatestEventsAfterDate(LocalDateTime of, LocalDateTime to, String[] events, String caseType);
 
     @QueryHints(value = {
             @QueryHint(name = HINT_FETCH_SIZE, value = "5000"),

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportService.java
@@ -91,7 +91,7 @@ public class CaseDataExportService extends CaseDataDynamicExportService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public void export(LocalDate from, LocalDate to, OutputStream outputStream, String caseType,
                        boolean convert, boolean convertHeader, ZonedDateTimeConverter zonedDateTimeConverter) throws IOException {
         var caseTypeDto = getCaseTypeCode(caseType);
@@ -154,7 +154,7 @@ public class CaseDataExportService extends CaseDataDynamicExportService {
 
         if (peggedTo.equals(LocalDate.now())) {
             return auditRepository.findAuditEventLatestEventsAfterDate(LocalDateTime.of(
-                    from, LocalTime.MIN), events, caseTypeCode);
+                    from, LocalTime.MIN), LocalDateTime.now(), events, caseTypeCode);
         }
         return auditRepository.findLastAuditDataByDateRangeAndEvents(LocalDateTime.of(
                 from, LocalTime.MIN), LocalDateTime.of(peggedTo, LocalTime.MAX),

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportServiceTest.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -56,7 +58,9 @@ public class CaseDataExportServiceTest extends BaseExportServiceTest {
                 outputStream, "TEST", false, false, zonedDateTimeConverter);
 
         // Verify that the latest table is used with future dates
-        verify(auditRepository).findAuditEventLatestEventsAfterDate(LocalDateTime.of(from, LocalTime.MIN), CaseDataExportService.EVENTS, "a1");
+        verify(auditRepository).findAuditEventLatestEventsAfterDate(eq(LocalDateTime.of(from, LocalTime.MIN)),
+                any(LocalDateTime.class),
+                eq(CaseDataExportService.EVENTS), eq("a1"));
 
         var result = outputStream.toString(StandardCharsets.UTF_8);
         Assertions.assertNotNull(result);


### PR DESCRIPTION
There is an issue with the implementation of the streaming with the
`audit_event_latest_events` query whereby upserting information during a
report pull could cause duplicate rows to be returned or missing data.

This change adds row locking when querying this table for the rows that
are returned. This stops any updates to happen while the data is being
read. As queries take less than 1 second on average, this should be more
than enough for most cases.

Improvements to the query have also been added so that inserts after the
report has been started in the database aren't returned - removing
post-added data from causing issues.