### PR TITLE
Peg match-label-action to version

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: label
-        uses: UKHomeOffice/match-label-action@v1.0.2
+        uses: UKHomeOffice/match-label-action@v1
         with:
           labels: minor,major,patch,skip-release
           mode: singular

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - id: label
-        uses: UKHomeOffice/match-label-action@v1.0.2
+        uses: UKHomeOffice/match-label-action@v1
         with:
           labels: minor,major,patch,skip-release
           mode: singular


### PR DESCRIPTION
Change the version to `v1`. While this does mean that we open ourselves
up to potential breaking changes in the action as we currently develop
this ourselves we can ensure changes are done in a way that doesn't
break backwards compatibility.