### PR TITLE
HOCS-5106: add team to extract data converter

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/AllocationExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/AllocationExportService.java
@@ -8,6 +8,7 @@ import uk.gov.digital.ho.hocs.audit.client.casework.CaseworkClient;
 import uk.gov.digital.ho.hocs.audit.client.info.InfoClient;
 import uk.gov.digital.ho.hocs.audit.client.info.dto.CaseTypeActionDto;
 import uk.gov.digital.ho.hocs.audit.client.info.dto.CaseTypeDto;
+import uk.gov.digital.ho.hocs.audit.client.info.dto.TeamDto;
 import uk.gov.digital.ho.hocs.audit.client.info.dto.UserDto;
 import uk.gov.digital.ho.hocs.audit.core.utils.ZonedDateTimeConverter;
 import uk.gov.digital.ho.hocs.audit.entrypoint.dto.AuditPayload;
@@ -80,6 +81,8 @@ public class AllocationExportService extends DynamicExportService {
 
         uuidToName.putAll(infoClient.getUsers().stream()
                 .collect(Collectors.toMap(UserDto::getId, UserDto::getUsername)));
+        uuidToName.putAll(infoClient.getAllTeams().stream()
+                .collect(Collectors.toMap(team -> team.getUuid().toString(), TeamDto::getDisplayName)));
         uuidToName.putAll(infoClient.getCaseTypeActions().stream()
                 .collect(Collectors.toMap(action -> action.getUuid().toString(), CaseTypeActionDto::getActionLabel)));
 


### PR DESCRIPTION
The `allocatedTo` column in the extracts contain both users and teams.
The teams are currently missing and so the UUIDs are just showing. This
change adds the missing call to retrieve all the teams.