### PR TITLE
HOCS-4995: add suspension export report

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/dto/AuditPayload.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/dto/AuditPayload.java
@@ -200,4 +200,11 @@ public interface AuditPayload {
 
     }
 
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    class Suspension {
+        private LocalDate dateSuspensionApplied;
+        private LocalDate dateSuspensionRemoved;
+    }
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/SuspensionExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/SuspensionExportService.java
@@ -1,0 +1,97 @@
+package uk.gov.digital.ho.hocs.audit.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.digital.ho.hocs.audit.client.casework.CaseworkClient;
+import uk.gov.digital.ho.hocs.audit.client.info.InfoClient;
+import uk.gov.digital.ho.hocs.audit.client.info.dto.CaseTypeDto;
+import uk.gov.digital.ho.hocs.audit.client.info.dto.UserDto;
+import uk.gov.digital.ho.hocs.audit.core.utils.ZonedDateTimeConverter;
+import uk.gov.digital.ho.hocs.audit.entrypoint.dto.AuditPayload;
+import uk.gov.digital.ho.hocs.audit.repository.AuditRepository;
+import uk.gov.digital.ho.hocs.audit.repository.entity.AuditEvent;
+import uk.gov.digital.ho.hocs.audit.service.domain.ExportType;
+import uk.gov.digital.ho.hocs.audit.service.domain.converter.ExportDataConverter;
+import uk.gov.digital.ho.hocs.audit.service.domain.converter.HeaderConverter;
+import uk.gov.digital.ho.hocs.audit.service.domain.converter.MalformedDateConverter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class SuspensionExportService extends DynamicExportService {
+
+    private static final String[] EVENTS = { "CASE_SUSPENSION_APPLIED", "CASE_SUSPENSION_REMOVED" };
+
+    public SuspensionExportService(ObjectMapper objectMapper, AuditRepository auditRepository, InfoClient infoClient, CaseworkClient caseworkClient, HeaderConverter headerConverter, MalformedDateConverter malformedDateConverter) {
+        super(objectMapper, auditRepository, infoClient, caseworkClient, headerConverter, malformedDateConverter);
+    }
+
+    @Override
+    public ExportType getExportType() {
+        return ExportType.SUSPENSIONS;
+    }
+
+    @Override
+    protected String[] parseData(AuditEvent audit, ZonedDateTimeConverter zonedDateTimeConverter, ExportDataConverter exportDataConverter) throws JsonProcessingException {
+        AuditPayload.Suspension suspensionData = objectMapper.readValue(audit.getAuditPayload(), AuditPayload.Suspension.class);
+
+        return new String[] {
+                zonedDateTimeConverter.convert(audit.getAuditTimestamp()),
+                audit.getType(),
+                exportDataConverter.convertValue(audit.getUserID()),
+                exportDataConverter.convertCaseUuid(audit.getCaseUUID()),
+                Objects.toString(suspensionData.getDateSuspensionApplied(), ""),
+                Objects.toString(suspensionData.getDateSuspensionRemoved(), "")
+        };
+    }
+
+    @Override
+    protected Stream<AuditEvent> getData(LocalDate from, LocalDate to, String caseTypeCode, String[] events) {
+        LocalDateTime peggedTo = to.isBefore(LocalDate.now()) ? LocalDateTime.of(to, LocalTime.MAX) : LocalDateTime.now();
+
+        return auditRepository.findAuditDataByDateRangeAndEvents(LocalDateTime.of(
+                        from, LocalTime.MIN), peggedTo,
+                events, caseTypeCode);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void export(LocalDate from, LocalDate to, OutputStream outputStream, String caseType, boolean convert, boolean convertHeader, ZonedDateTimeConverter zonedDateTimeConverter) throws IOException {
+        var caseTypeCode = getCaseTypeCode(caseType);
+
+        var data = getData(from, to, caseTypeCode.getShortCode(), EVENTS);
+        var dataConverter = getDataConverter(convert, caseTypeCode);
+
+        printData(outputStream, zonedDateTimeConverter, dataConverter, convertHeader, data);
+    }
+
+    @Override
+    protected String[] getHeaders() {
+        return new String[] {
+                "timestamp", "event", "userId", "caseUuid", "dateSuspensionApplied", "dateSuspensionRemoved"
+        };
+    }
+
+    @Override
+    protected ExportDataConverter getDataConverter(boolean convert, CaseTypeDto caseType) {
+        if (!convert) {
+            return new ExportDataConverter();
+        }
+
+        Map<String, String> uuidToName = infoClient.getUsers().stream()
+                .collect(Collectors.toMap(UserDto::getId, UserDto::getUsername));
+
+        return new ExportDataConverter(uuidToName, Collections.emptyMap(), caseType.getShortCode(), auditRepository);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/domain/ExportType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/domain/ExportType.java
@@ -8,5 +8,6 @@ public enum ExportType {
     CORRESPONDENTS,
     EXTENSIONS,
     INTERESTS,
-    TOPICS
+    TOPICS,
+    SUSPENSIONS
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/service/SuspensionExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/service/SuspensionExportServiceTest.java
@@ -1,0 +1,49 @@
+package uk.gov.digital.ho.hocs.audit.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.digital.ho.hocs.audit.client.info.dto.CaseTypeDto;
+import uk.gov.digital.ho.hocs.audit.core.utils.ZonedDateTimeConverter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
+
+public class SuspensionExportServiceTest extends BaseExportServiceTest{
+
+    @Autowired
+    private SuspensionExportService suspensionExportService;
+
+    private ZonedDateTimeConverter zonedDateTimeConverter;
+
+    @BeforeEach
+    public void setup() {
+        zonedDateTimeConverter = new ZonedDateTimeConverter();
+
+        given(infoClient.getCaseTypes())
+                .willReturn(Set.of(new CaseTypeDto("Test", "a1", "TEST")));
+    }
+
+    @Test
+    public void shouldReturnExport() throws IOException {
+        suspensionExportService.export(LocalDate.of(2020, 1, 1), LocalDate.now().plusDays(1),
+                outputStream, "TEST", false, false, zonedDateTimeConverter);
+
+        var result = outputStream.toString(StandardCharsets.UTF_8);
+        Assertions.assertNotNull(result);
+
+        var headers = getCsvHeaderRow(result);
+        Assertions.assertEquals(6, headers.length);
+
+        var rows = getCsvDataRows(result);
+        Assertions.assertEquals(1, rows.size());
+    }
+
+
+
+}


### PR DESCRIPTION
Add the suspension export report service that allows the user to request
a report based on the types: `CASE_SUSPENSION_APPLIED`,
`CASE_UNSUSPENDED`.