### PR TITLE
HOCS-5240: change to get all correspondents

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/client/casework/CaseworkClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/client/casework/CaseworkClient.java
@@ -25,8 +25,8 @@ public class CaseworkClient {
         this.serviceBaseURL = caseworkServiceUri;
     }
 
-    public Set<GetCorrespondentOutlineResponse> getAllActiveCorrespondents() {
-        GetCorrespondentOutlinesResponse response = restHelper.get(serviceBaseURL, "/correspondents", new ParameterizedTypeReference<>() {});
+    public Set<GetCorrespondentOutlineResponse> getAllCorrespondents() {
+        GetCorrespondentOutlinesResponse response = restHelper.get(serviceBaseURL, "/correspondents?includeDeleted=true", new ParameterizedTypeReference<>() {});
         return response.getCorrespondents();
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportService.java
@@ -134,7 +134,7 @@ public class CaseDataExportService extends CaseDataDynamicExportService {
                 .forEach(
                         topic -> uuidToName.putIfAbsent(topic.getTopicUUID().toString(), topic.getTopicText())
                 );
-        uuidToName.putAll(caseworkClient.getAllActiveCorrespondents().stream()
+        uuidToName.putAll(caseworkClient.getAllCorrespondents().stream()
                 .collect(Collectors.toMap(corr -> corr.getUuid().toString(), GetCorrespondentOutlineResponse::getFullname)));
         uuidToName.putAll(infoClient.getCaseTypeActions().stream()
                 .collect(Collectors.toMap(action -> action.getUuid().toString(), CaseTypeActionDto::getActionLabel)));

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/CorrespondentExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/CorrespondentExportService.java
@@ -116,7 +116,7 @@ public class CorrespondentExportService extends DynamicExportService {
 
         uuidToName.putAll(infoClient.getUsers().stream()
                 .collect(Collectors.toMap(UserDto::getId, UserDto::getUsername)));
-        uuidToName.putAll(caseworkClient.getAllActiveCorrespondents().stream()
+        uuidToName.putAll(caseworkClient.getAllCorrespondents().stream()
                 .collect(Collectors.toMap(corr -> corr.getUuid().toString(), GetCorrespondentOutlineResponse::getFullname)));
 
         return new ExportDataConverter(uuidToName, Collections.emptyMap(), caseType.getShortCode(), auditRepository);


### PR DESCRIPTION
Change to the casework call for getting correspondents to include
getting deleted ones. This will remove the fact that deleted
correspondents do not show in audit reports.