### PR TITLE
HOCS-5330: change db secret reference

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -258,33 +258,33 @@ spec:
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-rds-audit
-                  key: endpoint
+                  name: {{.KUBE_NAMESPACE}}-audit-rds
+                  key: host
             - name: DB_PORT
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-rds-audit
+                  name: {{.KUBE_NAMESPACE}}-audit-rds
                   key: port
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-rds-audit
-                  key: db_name
+                  name: {{.KUBE_NAMESPACE}}-audit-rds
+                  key: name
             - name: DB_SCHEMA_NAME
               valueFrom:
                 secretKeyRef:
-                  name: hocs-audit
-                  key: rds_schema
+                  name: {{.KUBE_NAMESPACE}}-audit-rds
+                  key: schema_name
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: hocs-audit
-                  key: rds_user
+                  name: {{.KUBE_NAMESPACE}}-audit-rds
+                  key: user_name
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: hocs-audit
-                  key: rds_password
+                  name: {{.KUBE_NAMESPACE}}-audit-rds
+                  key: password
             - name: AUDIT_QUEUE_NAME
               value: {{.KUBE_NAMESPACE}}-audit-sqs
             - name: AWS_SQS_AUDIT_URL


### PR DESCRIPTION
Change the secret reference to bring in line with the current standard
of `<namespace>-<service>-<rds>`.