### PR TITLE
Correct case data field reading order

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/repository/config/model/CaseDataFields.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/repository/config/model/CaseDataFields.java
@@ -3,16 +3,17 @@ package uk.gov.digital.ho.hocs.audit.repository.config.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
 public class CaseDataFields {
 
     @JsonValue
-    private final Map<String, Set<String>> caseTypeExportFields;
+    private final Map<String, LinkedHashSet<String>> caseTypeExportFields;
 
     @JsonCreator
-    public CaseDataFields(Map<String, Set<String>> caseTypeExportFields) {
+    public CaseDataFields(Map<String, LinkedHashSet<String>> caseTypeExportFields) {
         this.caseTypeExportFields = caseTypeExportFields;
     }
 


### PR DESCRIPTION
At present we are using a base HashSet that while ensures that
duplicates are stripped, does not provide us an exact gauranteed order.
This change changes the underlying collection to use a LinkedHashSet so
that we get the exact order that we specify in the configuration file.