### PR TITLE
Change SQS Listener Profile

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/AuditListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/AuditListener.java
@@ -14,7 +14,7 @@ import uk.gov.digital.ho.hocs.audit.service.AuditEventService;
 import java.util.Map;
 
 @Service
-@Profile("!extracts")
+@Profile("consumer")
 public class AuditListener {
 
     private final ObjectMapper objectMapper;

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/entrypoint/integration/BaseAwsSqsIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/entrypoint/integration/BaseAwsSqsIntegrationTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 
 @SpringBootTest
-@ActiveProfiles("local")
+@ActiveProfiles({"local", "consumer"})
 public class BaseAwsSqsIntegrationTest {
 
     private static final String APPROXIMATE_NUMBER_OF_MESSAGES = "ApproximateNumberOfMessages";


### PR DESCRIPTION
Change to use the `consumer` profile for listening to the queue rather than the `!extracts`. This allows for the service to opt in to being both a consumer and provider of extracts.