### PR TITLE
Add JPA Query and Lock Timeout

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,12 @@ spring:
       hibernate:
         temp:
           use_jdbc_metadata_defaults: false
-
+      javax:
+        persistence:
+          query:
+            timeout: 60000
+          lock:
+            timeout: 60000
 management:
   endpoints:
     enabled-by-default: false


### PR DESCRIPTION
Add a Query and Lock timeout for JPA requests, as connections are timed out after 2 minutes, allowing the underlying query to keep a lock and perform computations results in multiple requests causing OOM problems.