### PR TITLE
HOCS-6146: move materialised refresh to controller

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/AdminResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/AdminResource.java
@@ -1,0 +1,35 @@
+package uk.gov.digital.ho.hocs.audit.entrypoint;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.digital.ho.hocs.audit.service.CustomExportService;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@RestController
+public class AdminResource {
+
+    private final CustomExportService customExportService;
+
+    public AdminResource(CustomExportService customExportService) {
+        this.customExportService = customExportService;
+    }
+
+    @PostMapping(value = "/admin/export/custom/{viewName}/refresh")
+    public @ResponseBody void refreshMaterialisedView(HttpServletResponse response,
+                                                      @PathVariable("viewName") String viewName) {
+        try {
+            customExportService.refreshMaterialisedView(viewName);
+            response.setStatus(HttpStatus.OK.value());
+        } catch (Exception ex) {
+            log.error("Error refreshing materialised view {}: {}", viewName, ex.getMessage());
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/CustomExportResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/CustomExportResource.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,18 +45,6 @@ public class CustomExportResource {
             } else {
                 response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
             }
-        }
-    }
-
-    @PostMapping(value = "/admin/export/custom/{viewName}/refresh")
-    public @ResponseBody void refreshMaterialisedView(HttpServletResponse response,
-                                                      @PathVariable("viewName") String viewName) {
-        try {
-            customExportService.refreshMaterialisedView(viewName);
-            response.setStatus(HttpStatus.OK.value());
-        } catch (Exception ex) {
-            log.error("Error refreshing materialised view {}: {}", viewName, ex.getMessage());
-            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         }
     }
 


### PR DESCRIPTION
Move the `refreshMaterialisedView` method to its own controller not imposed by the `extracts` profile. While this works - the imposed 1 minute timeout kills the underlying refresh.

Moving this to its own controller allows for the main `hocs-audit` deployment to trigger the refresh. This still has the 1 minute timeout applied - but this can be turned off for now.