### PR TITLE
HOCS-6150: rework audit latest event usage

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/audit/repository/AuditRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/repository/AuditRepository.java
@@ -54,15 +54,6 @@ public interface AuditRepository extends JpaRepository<AuditEvent, String>, Audi
 
     @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "5000"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = READ_ONLY, value = "true") })
-    @Query(value = "SELECT a.* FROM audit_event_latest_events a " + "WHERE a.audit_timestamp BETWEEN ?1 AND ?2 AND " + "a.type IN ?3 AND " + "a.case_type = ?4 AND " + "a.deleted = false ORDER BY a.case_uuid, a.type, a.audit_timestamp DESC " + "FOR UPDATE",
-           nativeQuery = true)
-    Stream<AuditEvent> findAuditEventLatestEventsAfterDate(LocalDateTime of,
-                                                           LocalDateTime to,
-                                                           String[] events,
-                                                           String caseType);
-
-    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "5000"),
-        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = READ_ONLY, value = "true") })
     @Query(value = "SELECT audit_payload->>'reference' AS caseReference, cast(case_uuid AS VARCHAR(36)) as caseUuid FROM audit_event_latest_events WHERE type = 'CASE_CREATED' AND case_type = ?1",
            nativeQuery = true)
     Stream<CaseReference> getCaseReferencesForType(String caseType);

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportService.java
@@ -157,10 +157,6 @@ public class CaseDataExportService extends CaseDataDynamicExportService {
             ? LocalDateTime.of(to, LocalTime.MAX)
             : LocalDateTime.now();
 
-        if (peggedTo.toLocalDate().equals(LocalDate.now())) {
-            return auditRepository.findAuditEventLatestEventsAfterDate(LocalDateTime.of(from, LocalTime.MIN),
-                LocalDateTime.now(), events, caseTypeCode);
-        }
         return auditRepository.findLastAuditDataByDateRangeAndEvents(LocalDateTime.of(from, LocalTime.MIN), peggedTo,
             events, caseTypeCode);
     }

--- a/src/main/resources/db/migration/postgresql/V1_15__REWORK_LATEST_EVENT_TRIGGER_CASE_CREATED.sql
+++ b/src/main/resources/db/migration/postgresql/V1_15__REWORK_LATEST_EVENT_TRIGGER_CASE_CREATED.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE TRIGGER auditEventLatestTypesTrigger
+    AFTER INSERT ON audit_event
+    FOR EACH ROW
+    WHEN (NEW.type in ('CASE_CREATED'))
+EXECUTE PROCEDURE upsertLatestAuditEvents();

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/service/CaseDataExportServiceTest.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -45,32 +43,6 @@ public class CaseDataExportServiceTest extends BaseExportServiceTest {
         zonedDateTimeConverter = new ZonedDateTimeConverter();
 
         given(infoClient.getCaseTypes()).willReturn(Set.of(new CaseTypeDto("Test", "a1", "TEST")));
-    }
-
-    @Test
-    public void shouldReturnLatestCaseDataReport() throws IOException {
-        LocalDate from = LocalDate.of(2020, 1, 1);
-        caseDataExportService.export(from, LocalDate.now().plusDays(1), outputStream, "TEST", false, false,
-            zonedDateTimeConverter);
-
-        // Verify that the latest table is used with future dates
-        verify(auditRepository).findAuditEventLatestEventsAfterDate(eq(LocalDateTime.of(from, LocalTime.MIN)),
-            any(LocalDateTime.class), eq(CaseDataExportService.EVENTS), eq("a1"));
-
-        var result = outputStream.toString(StandardCharsets.UTF_8);
-        Assertions.assertNotNull(result);
-
-        var headers = getCsvHeaderRow(result);
-        Assertions.assertEquals(10, headers.length);
-
-        var rows = getCsvDataRows(result).stream().map(CSVRecord::toList).collect(Collectors.toList());
-        var expectedRows = List.of(
-            List.of("2020-01-01T00:00:00.000000", "CASE_CREATED", "40000000-0000-0000-0000-000000000000",
-                "10000000-0000-0000-0000-000000000000", "TEST", "", "", "", "", ""),
-            List.of(getTodaysLocalDateTime(), "CASE_UPDATED", "40000000-0000-0000-0000-000000000000",
-                "10000000-0000-0000-0000-000000000000", "TEST", "", "", "", "", "TEST-1"));
-        Assertions.assertEquals(3, rows.size());
-        Assertions.assertTrue(rows.containsAll(expectedRows));
     }
 
     @Test


### PR DESCRIPTION
Remove the usage of the latest event table from the CASE_DATA event as
this cannot be run on a read-only replica. This table is still used on
converted extracts.

Repurpose the latest events trigger to only store the CASE_CREATED
events.