### PR TITLE
HOCS-6202: Add ChooseExternalContractor case data field for COMP2 cas…

### DIFF
--- a/src/main/resources/config/case-data-fields.json
+++ b/src/main/resources/config/case-data-fields.json
@@ -286,7 +286,8 @@
     "PsuReference",
     "PsuTriageOutcome",
     "PsuComplaintOutcome",
-    "WithdrawalReason"
+    "WithdrawalReason",
+    "ChooseExternalContractor"
   ],
   "DTEN": [
     "DateOfCorrespondence",


### PR DESCRIPTION
HOCS-6202: This PR would help to add ChooseExternalContractor 
field to COMP2 case so when the case details are extracts, it 
should contact pulling this content as well (either Sopra Steria or 
Migrant Help as the values).