### PR TITLE
Change docker entrypoint to org.springframework.boot.loader.launch.JarLauncher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=builder --chown=user_hocs:group_hocs ./builder/application/ ./
 
 USER 10000
 
-ENTRYPOINT exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+ENTRYPOINT exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher


### PR DESCRIPTION
In springboot 3.2 the module path for their JarLauncher that we use as an entrypoint has changed.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes#nested-jar-support
https://medium.com/viascom/spring-boot-3-2-x-jarlauncher-path-a3656f8e69b4