### PR TITLE
HOCS-7048--add-filters-to-dcu-custom-reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=builder --chown=user_hocs:group_hocs ./builder/application/ ./
 
 USER 10000
 
-ENTRYPOINT exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher
+ENTRYPOINT exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2022.0.4"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.awaitility:awaitility:4.2.1'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation("jakarta.json:jakarta.json-api:2.1.3")
 
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
-    implementation 'org.apache.commons:commons-csv:1.11.0'
+    implementation 'org.apache.commons:commons-csv:1.10.0'
 
     implementation 'org.flywaydb:flyway-core:9.19.3'
     runtimeOnly 'org.postgresql:postgresql:42.7.3'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.5'
 }
 
-def lombokVersion = '1.18.32'
+def lombokVersion = '1.18.30'
 
 group = 'uk.gov.digital.ho.hocs'
 sourceCompatibility = JavaVersion.VERSION_17

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'org.springframework:spring-messaging:5.3.24'
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
-    implementation("jakarta.json:jakarta.json-api:2.1.3")
+    implementation("jakarta.json:jakarta.json-api:2.1.1")
 
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     implementation 'org.apache.commons:commons-csv:1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.1'
+    id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.5'
 }
 
-def lombokVersion = '1.18.36'
+def lombokVersion = '1.18.32'
 
 group = 'uk.gov.digital.ho.hocs'
 sourceCompatibility = JavaVersion.VERSION_17
@@ -21,9 +21,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-undertow'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation group: 'io.awspring.cloud', name: 'spring-cloud-aws-starter', version: '3.2.1'
-    implementation group: 'io.awspring.cloud', name: 'spring-cloud-aws-starter-sqs', version: '3.2.1'
-    implementation 'org.springframework:spring-messaging:6.2.1'
+    implementation group: 'io.awspring.cloud', name: 'spring-cloud-aws-messaging', version: '2.4.4'
+    implementation 'org.springframework:spring-messaging:5.3.24'
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation("jakarta.json:jakarta.json-api:2.1.3")
@@ -45,7 +44,7 @@ dependencies {
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.0"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
     }
 }
 
@@ -55,11 +54,4 @@ jar {
 
 test {
     useJUnitPlatform()
-
-    systemProperty 'spring.profiles.active', 'local,test'
-
-    testLogging {
-        exceptionFormat = 'full'
-        showStackTraces = true
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.5'
-    id 'io.spring.dependency-management' version '1.1.5'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 def lombokVersion = '1.18.30'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation group: 'io.awspring.cloud', name: 'spring-cloud-aws-messaging', version: '2.4.4'
     implementation 'org.springframework:spring-messaging:5.3.24'
 
-    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.3'
     implementation("jakarta.json:jakarta.json-api:2.1.1")
 
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'org.apache.commons:commons-csv:1.10.0'
 
     implementation 'org.flywaydb:flyway-core:9.19.3'
-    runtimeOnly 'org.postgresql:postgresql:42.7.3'
+    runtimeOnly 'org.postgresql:postgresql:42.6.0'
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.5'
+    id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.apache.commons:commons-csv:1.11.0'
 
     implementation 'org.flywaydb:flyway-core:9.19.3'
-    runtimeOnly 'org.postgresql:postgresql:42.7.4'
+    runtimeOnly 'org.postgresql:postgresql:42.7.3'
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/config/materializedviews/Audit-Schema-DataUpdates.sql
+++ b/config/materializedviews/Audit-Schema-DataUpdates.sql
@@ -244,6 +244,13 @@ WITH NO DATA;
 
 CREATE UNIQUE INDEX idx_dcu_aggregated_cases_temp_case_uuid ON DCU_AGGREGATED_CASES_TEMP("caseUuid");
 
+CREATE INDEX idx_dcu_aggregated_cases_temp_case_completed ON DCU_AGGREGATED_CASES_TEMP("caseCompleted");
+CREATE INDEX idx_dcu_aggregated_cases_temp_case_created ON DCU_AGGREGATED_CASES_TEMP("caseCreated");
+CREATE INDEX idx_dcu_aggregated_cases_temp_case_deadline ON DCU_AGGREGATED_CASES_TEMP("caseDeadline");
+CREATE INDEX idx_dcu_aggregated_cases_temp_case_status ON DCU_AGGREGATED_CASES_TEMP("caseStatus");
+CREATE INDEX idx_dcu_aggregated_cases_temp_last_modified ON DCU_AGGREGATED_CASES_TEMP("lastModified");
+CREATE INDEX idx_dcu_aggregated_cases_temp_latest_data_change ON DCU_AGGREGATED_CASES_TEMP("latestDataChange");
+
 REFRESH MATERIALIZED VIEW DCU_AGGREGATED_CASES_TEMP;
 
 DROP MATERIALIZED VIEW IF EXISTS DCU_AGGREGATED_CASES CASCADE;
@@ -251,6 +258,13 @@ DROP MATERIALIZED VIEW IF EXISTS DCU_AGGREGATED_CASES CASCADE;
 ALTER TABLE DCU_AGGREGATED_CASES_TEMP RENAME TO DCU_AGGREGATED_CASES;
 
 ALTER INDEX idx_dcu_aggregated_cases_temp_case_uuid RENAME TO idx_dcu_aggregated_cases_case_uuid;
+
+ALTER INDEX idx_dcu_aggregated_cases_temp_case_completed RENAME TO idx_dcu_aggregated_cases_case_completed;
+ALTER INDEX idx_dcu_aggregated_cases_temp_case_created RENAME TO idx_dcu_aggregated_cases_case_created;
+ALTER INDEX idx_dcu_aggregated_cases_temp_case_deadline RENAME TO idx_dcu_aggregated_cases_case_deadline;
+ALTER INDEX idx_dcu_aggregated_cases_temp_case_status RENAME TO idx_dcu_aggregated_cases_case_status;
+ALTER INDEX idx_dcu_aggregated_cases_temp_last_modified RENAME TO idx_dcu_aggregated_cases_last_modified;
+ALTER INDEX idx_dcu_aggregated_cases_temp_latest_data_change RENAME TO idx_dcu_aggregated_cases_latest_data_change;
 
 DROP VIEW IF EXISTS DCU_PRAU_WORKFLOW;
 
@@ -399,3 +413,4 @@ SELECT
      ,"last_refresh"
 FROM DCU_AGGREGATED_CASES;
 
+-- REFRESH MATERIALIZED VIEW DCU_AGGREGATED_CASES;

--- a/config/materializedviews/cs-prod-update-audit-materialized-views.yml
+++ b/config/materializedviews/cs-prod-update-audit-materialized-views.yml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hocs-update-materialized-views
+  labels:
+    role: hocs-update-materialized-views
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        name: hocs-update-materialized-views
+        role: hocs-update-materialized-views
+        database: required
+    spec:
+      containers:
+        - name: hocs-update-materialized-views
+          image: quay.io/ukhomeofficedigital/hocs-toolbox:1.7.1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - psql -tA -f sql/Audit-Schema-DataUpdates.sql
+          env:
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: cs-prod-audit-rds
+                  key: host
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: cs-prod-audit-rds
+                  key: name
+            - name: DB_SCHEMA_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cs-prod-audit-rds
+                  key: schema_name
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: cs-prod-audit-rds
+                  key: user_name
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cs-prod-audit-rds
+                  key: password
+      restartPolicy: Never

--- a/config/materializedviews/cs-qa-update-audit-materialized-views.yml
+++ b/config/materializedviews/cs-qa-update-audit-materialized-views.yml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hocs-update-materialized-views
+  labels:
+    role: hocs-update-materialized-views
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        name: hocs-update-materialized-views
+        role: hocs-update-materialized-views
+        database: required
+    spec:
+      containers:
+        - name: hocs-update-materialized-views
+          image: quay.io/ukhomeofficedigital/hocs-toolbox:1.7.1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - psql -tA -f sql/Audit-Schema-DataUpdates.sql
+          env:
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: cs-qa-audit-rds
+                  key: host
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: cs-qa-audit-rds
+                  key: name
+            - name: DB_SCHEMA_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cs-qa-audit-rds
+                  key: schema_name
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: cs-qa-audit-rds
+                  key: user_name
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cs-qa-audit-rds
+                  key: password
+      restartPolicy: Never

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/core/config/sqs/LocalStackConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/core/config/sqs/LocalStackConfiguration.java
@@ -1,56 +1,40 @@
 package uk.gov.digital.ho.hocs.audit.core.config.sqs;
 
-
-import io.awspring.cloud.autoconfigure.sqs.SqsProperties;
-import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
-import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
+import io.awspring.cloud.messaging.config.annotation.EnableSqs;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
-import java.net.URI;
-
-@Import(SqsBootstrapConfiguration.class)
+@EnableSqs
 @Configuration
 @Profile({ "local" })
 public class LocalStackConfiguration {
 
     @Primary
     @Bean
-    public SqsAsyncClient awsSqsClient(@Value("${aws.sqs.config.url}") URI awsBaseUrl) {
-
-        AwsCredentials credentials = AwsBasicCredentials.create("test", "test");
-
-        return SqsAsyncClient.builder()
-                             .region(Region.EU_WEST_2)
-                             .credentialsProvider(StaticCredentialsProvider.create(credentials))
-            .endpointOverride(awsBaseUrl)
-                             .build();
+    public AmazonSQSAsync awsSqsClient(@Value("${aws.sqs.config.url}") String awsBaseUrl) {
+        return AmazonSQSAsyncClientBuilder.standard().withCredentials(
+            new AWSStaticCredentialsProvider(new BasicAWSCredentials("test", "test"))).withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(awsBaseUrl, "eu-west-2")).build();
     }
 
     @Primary
     @Bean
-    public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(SqsAsyncClient amazonSqs) {
-        return SqsMessageListenerContainerFactory
-            .builder()
-            .sqsAsyncClient(amazonSqs)
-            .build();
-    }
+    public SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory(AmazonSQSAsync amazonSqs) {
+        SimpleMessageListenerContainerFactory factory = new SimpleMessageListenerContainerFactory();
 
-    @Primary
-    @Bean
-    public SqsProperties.Listener listener() {
-        var listener = new SqsProperties.Listener();
-        listener.setMaxConcurrentMessages(10);
-        return listener;
+        factory.setAmazonSqs(amazonSqs);
+        factory.setMaxNumberOfMessages(10);
+
+        return factory;
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/core/config/sqs/SqsConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/core/config/sqs/SqsConfiguration.java
@@ -1,53 +1,43 @@
 package uk.gov.digital.ho.hocs.audit.core.config.sqs;
 
-
-import io.awspring.cloud.autoconfigure.sqs.SqsProperties.Listener;
-import io.awspring.cloud.sqs.config.SqsBootstrapConfiguration;
-import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
+import io.awspring.cloud.messaging.config.annotation.EnableSqs;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
-@Import(SqsBootstrapConfiguration.class)
+@EnableSqs
 @Configuration
 @Profile({ "sqs" })
 public class SqsConfiguration {
 
     @Primary
     @Bean
-    public SqsAsyncClient awsSqsClient(@Value("${aws.sqs.access.key}") String accessKey,
+    public AmazonSQSAsync awsSqsClient(@Value("${aws.sqs.access.key}") String accessKey,
                                        @Value("${aws.sqs.secret.key}") String secretKey,
-                                       @Value("${aws.sqs.region}") Region region) {
-        AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+                                       @Value("${aws.sqs.region}") String region) {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
-        return SqsAsyncClient.builder()
-                             .region(region)
-                             .credentialsProvider(StaticCredentialsProvider.create(credentials))
-                             .build();
+        return AmazonSQSAsyncClientBuilder.standard().withRegion(region).withCredentials(
+            new AWSStaticCredentialsProvider(credentials)).build();
     }
 
     @Primary
     @Bean
-    public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(SqsAsyncClient amazonSqs) {
-        return SqsMessageListenerContainerFactory
-            .builder()
-            .sqsAsyncClient(amazonSqs)
-            .build();
+    public SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory(AmazonSQSAsync amazonSqs) {
+        SimpleMessageListenerContainerFactory factory = new SimpleMessageListenerContainerFactory();
+
+        factory.setAmazonSqs(amazonSqs);
+        factory.setMaxNumberOfMessages(10);
+
+        return factory;
     }
 
-    @Primary
-    @Bean
-    public Listener listener() {
-        var listener = new Listener();
-        listener.setMaxConcurrentMessages(10);
-        return listener;
-    }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/AuditListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/AuditListener.java
@@ -2,7 +2,8 @@ package uk.gov.digital.ho.hocs.audit.entrypoint;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,7 @@ public class AuditListener {
         this.requestData = requestData;
     }
 
-    @SqsListener(value = "${aws.sqs.audit.url}", acknowledgementMode = "ON_SUCCESS")
+    @SqsListener(value = "${aws.sqs.audit.url}", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
     public void onAuditEvent(String message, @Headers Map<String, String> headers) throws JsonProcessingException {
         try {
             requestData.parseMessageHeaders(headers);

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/dto/CustomExportFilter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/entrypoint/dto/CustomExportFilter.java
@@ -1,0 +1,174 @@
+package uk.gov.digital.ho.hocs.audit.entrypoint.dto;
+
+import uk.gov.digital.ho.hocs.audit.repository.config.model.CustomExportViews.CustomExportView;
+import uk.gov.digital.ho.hocs.audit.repository.config.model.CustomExportViews.CustomExportView.Filter;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public record CustomExportFilter(
+    String column,
+    LocalDate dateFrom,
+    LocalDate dateTo,
+    String value,
+    boolean includeEmpty
+) {
+
+    public static class FilterValidationException extends Exception {
+        public FilterValidationException(String message) {
+            super(message);
+        }
+    }
+
+    public static final class ValidatedFilter {
+        private final String whereClause;
+
+        private ValidatedFilter(String whereClause) {this.whereClause = whereClause;}
+
+        public String whereClause() {
+            return whereClause;
+        }
+    }
+
+    public ValidatedFilter validate(CustomExportView customExportView) throws FilterValidationException {
+        if (Objects.isNull(column)) {
+            return validateNullFilter();
+        }
+
+        List<String> whereClauses = validateColumnFilters(customExportView);
+
+        if (whereClauses.isEmpty()) {
+            throw new FilterValidationException(
+                "A date range, value, and/or includeEmpty is required if column is not null"
+            );
+        }
+
+        return new ValidatedFilter(
+            String.format("WHERE %s", String.join(" OR ", whereClauses))
+        );
+    }
+
+    private List<String> validateColumnFilters(CustomExportView customExportView) throws FilterValidationException {
+        Filter filter = lookupExportFieldFilter(customExportView);
+        List<String> whereClauses = new ArrayList<>();
+
+        if (!Objects.isNull(dateFrom) || !Objects.isNull(dateTo)) {
+            whereClauses.add(validateDateFilter(filter, customExportView));
+        } else if (!Objects.isNull(value)) {
+            whereClauses.add(validateValueFilter(filter, customExportView));
+        }
+
+        if (includeEmpty) {
+            whereClauses.add(validateEmptyFilter(filter, customExportView));
+        }
+
+        return whereClauses;
+    }
+
+    public String columnRef(CustomExportView customExportView) {
+        return String.format("%s.\"%s\"", customExportView.viewName(), column);
+    }
+
+    private String validateEmptyFilter(Filter filter, CustomExportView view) throws FilterValidationException {
+        if (!filter.nullable()) {
+            throw new FilterValidationException(
+                String.format("%s can not be filtered to empty values", column)
+            );
+        }
+
+        return String.format("%s IS NULL", columnRef(view));
+    }
+
+    private String validateValueFilter(Filter filter, CustomExportView view) throws FilterValidationException {
+        if (filter.filterType() != CustomExportView.FilterType.Value) {
+            throw new FilterValidationException(String.format("%s can not be filtered by value", column));
+        }
+
+        List<String> filterOptions = Objects.requireNonNull(filter.options());
+
+        if (!filterOptions.contains(value)) {
+            throw new FilterValidationException(String.format("%s is not a valid value for %s", value, column));
+        }
+
+        return String.format("%s = '%s'", columnRef(view), value);
+    }
+
+    private String validateDateFilter(Filter filter, CustomExportView view) throws FilterValidationException {
+        if (!Objects.isNull(value)) {
+            throw new FilterValidationException("A column can't be filtered both by date and value");
+        }
+
+        if (filter.filterType() != CustomExportView.FilterType.DateRange) {
+            throw new FilterValidationException(String.format("%s is not a date column", column));
+        }
+
+        if (!Objects.isNull(dateFrom)) {
+            if (Objects.isNull(dateTo)) {
+                return String.format(
+                    "%s >= '%s 00:00:00'",
+                    columnRef(view),
+                    dateFrom.format(DateTimeFormatter.ISO_DATE)
+                );
+            }
+
+            if (dateTo.isBefore(dateFrom)) {
+                throw new FilterValidationException("dateFrom must be before dateTo");
+            }
+
+            return String.format(
+                "%s BETWEEN '%s 00:00:00' AND '%s 23:59:59'",
+                columnRef(view),
+                dateFrom.format(DateTimeFormatter.ISO_DATE),
+                dateTo.format(DateTimeFormatter.ISO_DATE)
+            );
+        }
+
+        return String.format(
+            "%s <= '%s 23:59:59'",
+            columnRef(view),
+            dateTo.format(DateTimeFormatter.ISO_DATE)
+        );
+    }
+
+    private Filter lookupExportFieldFilter(CustomExportView customExportView) throws FilterValidationException {
+        Optional<CustomExportView.ExportField> maybeField =
+            customExportView.fields().stream()
+                            .filter(f -> Objects.equals(f.name(), column))
+                            .findAny();
+
+        if (maybeField.isEmpty()) {
+            throw new FilterValidationException(
+                String.format("%s is not a column in export %s", column, customExportView.displayName())
+            );
+        }
+
+        CustomExportView.ExportField field = maybeField.get();
+        if (field.filter() == null) {
+            throw new FilterValidationException(
+                String.format("%s is not filterable", column)
+            );
+        }
+
+        return field.filter();
+    }
+
+    private ValidatedFilter validateNullFilter() throws FilterValidationException {
+        if (!Objects.isNull(dateFrom) || !Objects.isNull(dateTo)) {
+            throw new FilterValidationException("Column must be provided to filter by a date range");
+        }
+
+        if (!Objects.isNull(value)) {
+            throw new FilterValidationException("Column must be provided to filter by a value");
+        }
+
+        if (includeEmpty) {
+            throw new FilterValidationException("Column must be provided to filter by empty values");
+        }
+
+        return new ValidatedFilter("");
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/repository/AuditRepositoryCustom.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/repository/AuditRepositoryCustom.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.hocs.audit.repository;
 
 import org.springframework.stereotype.Repository;
+import uk.gov.digital.ho.hocs.audit.entrypoint.dto.CustomExportFilter;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;
@@ -8,7 +9,7 @@ import java.util.stream.Stream;
 @Repository
 public interface AuditRepositoryCustom {
 
-    Stream<Object[]> getResultsFromView(String viewName);
+    Stream<Object[]> getResultsFromView(String viewName, CustomExportFilter.ValidatedFilter filter);
 
     void refreshMaterialisedView(String viewName);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/repository/config/model/CustomExportViews.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/repository/config/model/CustomExportViews.java
@@ -3,11 +3,9 @@ package uk.gov.digital.ho.hocs.audit.repository.config.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
-import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class CustomExportViews {
 
@@ -23,38 +21,46 @@ public class CustomExportViews {
         return customExportViews.get(viewName);
     }
 
-    @Getter
-    public static class CustomExportView {
-
-        private final String requiredPermission;
-
-        private final String displayName;
-
-        @JsonValue
-        private final List<ExportField> fields;
-
+    public record CustomExportView(
+        String requiredPermission,
+        String displayName,
+        String viewName,
+        List<ExportField> fields
+    ) {
         @JsonCreator
-        public CustomExportView(@JsonProperty("requiredPermission") String requiredPermission,
-                                @JsonProperty("displayName") String displayName,
-                                @JsonProperty("fields") List<ExportField> fields) {
+        public CustomExportView(
+            @JsonProperty("requiredPermission") String requiredPermission,
+            @JsonProperty("displayName") String displayName,
+            @JsonProperty("viewName") String viewName,
+            @JsonProperty("fields") List<ExportField> fields
+        ) {
             this.requiredPermission = requiredPermission;
             this.displayName = displayName;
+            this.viewName = viewName;
             this.fields = fields;
         }
 
-        @Getter
-        public static class ExportField {
+        public enum FilterType {
+            DateRange,
+            Value
+        }
 
-            private final String name;
+        public record Filter(
+            @JsonProperty(value = "type", required = true) FilterType filterType,
+            @JsonProperty(value = "nullable", defaultValue = "false") boolean nullable,
+            @JsonProperty("options") List<String> options) {}
 
-            private final String adapter;
-
+        public record ExportField(String name, String adapter, Filter filter) {
             @JsonCreator
-            public ExportField(@JsonProperty("name") String name, @JsonProperty("adapter") String adapter) {
+            public ExportField(
+                @JsonProperty("name") String name,
+                @JsonProperty("adapter") String adapter,
+                @JsonProperty("filter") Filter filter
+            ) {
                 this.name = name;
                 this.adapter = adapter;
+                this.filter = filter;
             }
-
         }
 
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/audit/service/domain/converter/CustomExportDataConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/audit/service/domain/converter/CustomExportDataConverter.java
@@ -50,9 +50,9 @@ public class CustomExportDataConverter {
     public String[] getHeaders(CustomExportViews.CustomExportView exportView) {
         List<String> headers = new ArrayList<>();
 
-        for (var field : exportView.getFields()) {
-            if (!shouldHide(field)) {
-                headers.add(field.getName());
+        for (var field : exportView.fields()) {
+            if (shouldShow(field)) {
+                headers.add(field.name());
             }
         }
 
@@ -73,8 +73,8 @@ public class CustomExportDataConverter {
         List<String> results = new ArrayList<>();
         int index = 0;
         for (var field : fields) {
-            if (!shouldHide(field)) {
-                results.add(applyAdapter(rawData[index], field.getAdapter()));
+            if (shouldShow(field)) {
+                results.add(applyAdapter(rawData[index], field.adapter()));
             }
             index++;
         }
@@ -102,8 +102,8 @@ public class CustomExportDataConverter {
         return result == null ? null : String.valueOf(result);
     }
 
-    private boolean shouldHide(ExportField field) {
-        return ExportViewConstants.FIELD_ADAPTER_HIDDEN.equals(field.getAdapter());
+    private boolean shouldShow(ExportField field) {
+        return !ExportViewConstants.FIELD_ADAPTER_HIDDEN.equals(field.adapter());
     }
 
     public void initialiseAdapters() {

--- a/src/main/resources/application-extracts.yml
+++ b/src/main/resources/application-extracts.yml
@@ -1,2 +1,0 @@
-server:
-  port: 8094

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,7 +14,3 @@ aws:
 
 
 postgresViewAllowList: allow1,allow2
-
-management:
-  endpoints:
-    enabled-by-default: true

--- a/src/main/resources/config/custom-export-views.json
+++ b/src/main/resources/config/custom-export-views.json
@@ -2,6 +2,7 @@
   "DCU_PRAU_WORKFLOW": {
     "requiredPermission": "DCU_EXPORT_USER",
     "displayName": "dcu-prau-workflow",
+    "viewName": "dcu_prau_workflow",
     "fields": [
       {
         "name": "assignedTeam",
@@ -181,6 +182,7 @@
   "DCU_BUSINESS": {
     "displayName": "dcu-business",
     "requiredPermission": "DCU_EXPORT_USER",
+    "viewName": "dcu_business",
     "fields": [
       {
         "name": "assignedTeam",
@@ -198,16 +200,20 @@
         "name": "assignedUserUpdated"
       },
       {
-        "name": "caseCompleted"
+        "name": "caseCompleted",
+        "filter": {"type": "DateRange", "nullable":  true}
       },
       {
-        "name": "caseCreated"
+        "name": "caseCreated",
+        "filter": {"type": "DateRange", "nullable":  false}
       },
       {
-        "name": "caseDeadline"
+        "name": "caseDeadline",
+        "filter": {"type": "DateRange", "nullable":  false}
       },
       {
-        "name": "caseStatus"
+        "name": "caseStatus",
+        "filter": {"type": "Value", "options": ["Case Completed","In Progress", "NRN", "OGD"]}
       },
       {
         "name": "caseType"
@@ -263,14 +269,16 @@
         "name": "initialDraftDeadline"
       },
       {
-        "name": "lastModified"
+        "name": "lastModified",
+        "filter": {"type": "DateRange", "nullable":  false}
       },
       {
         "name": "lastModifiedBy",
         "adapter": "userEmailAdapter"
       },
       {
-        "name": "latestDataChange"
+        "name": "latestDataChange",
+        "filter": {"type": "DateRange", "nullable":  false}
       },
       {
         "name": "latestStageChange"

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/entrypoint/dto/CustomExportFilterTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/entrypoint/dto/CustomExportFilterTest.java
@@ -1,0 +1,319 @@
+package uk.gov.digital.ho.hocs.audit.entrypoint.dto;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.digital.ho.hocs.audit.repository.config.model.CustomExportViews;
+import uk.gov.digital.ho.hocs.audit.repository.config.model.CustomExportViews.CustomExportView.ExportField;
+import uk.gov.digital.ho.hocs.audit.repository.config.model.CustomExportViews.CustomExportView.Filter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.digital.ho.hocs.audit.repository.config.model.CustomExportViews.CustomExportView.FilterType.DateRange;
+import static uk.gov.digital.ho.hocs.audit.repository.config.model.CustomExportViews.CustomExportView.FilterType.Value;
+
+class CustomExportFilterTest {
+
+    private CustomExportViews.CustomExportView exampleView(List<ExportField> fields) {
+        return new CustomExportViews.CustomExportView(
+            "permission",
+            "displayName",
+            "viewName",
+            fields
+        );
+    }
+
+    @Test
+    void validateGeneratesAnEmptyWhereClauseWhenNoFiltersAreProvided() throws CustomExportFilter.FilterValidationException {
+        var filter = new CustomExportFilter(null, null, null, null, false);
+        var exportView = exampleView(List.of());
+
+        var validated = filter.validate(exportView);
+
+        assertEquals("", validated.whereClause());
+    }
+
+    public static Stream<Arguments> missingColumnExamples() {
+        return Stream.of(
+            Arguments.of(
+                new CustomExportFilter(null, LocalDate.of(2025, 1, 1), null, null, false),
+                "Column must be provided to filter by a date range"
+            ),
+            Arguments.of(
+                new CustomExportFilter(null, null, LocalDate.of(2025, 1, 1), null, false),
+                "Column must be provided to filter by a date range"
+            ),
+            Arguments.of(
+                new CustomExportFilter(null, null, null, "value", false),
+                "Column must be provided to filter by a value"
+            ),
+            Arguments.of(
+                new CustomExportFilter(null, null, null, null, true),
+                "Column must be provided to filter by empty values"
+            )
+        );
+    }
+
+    @ParameterizedTest(name = "{1} thrown on missing column")
+    @MethodSource("missingColumnExamples")
+    void validateFailsWhenMissingAColumn(CustomExportFilter filter, String expectedMessage) {
+        var exportView = exampleView(List.of());
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Test
+    void validateFailsWhenFilteringOnAnInvalidColumn() {
+        var filter = new CustomExportFilter("columnName", null, null, null, false);
+        var exportView = exampleView(List.of());
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("columnName is not a column in export displayName", exception.getMessage());
+    }
+
+    @Test
+    void validateFailsWhenFilteringOnAColumnWithoutAFilter() {
+        var filter = new CustomExportFilter("columnName", null, null, null, false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, null))
+        );
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("columnName is not filterable", exception.getMessage());
+    }
+
+    @Test
+    void validateFailsWhenNoFilterParametersAreProvided() {
+        var filter = new CustomExportFilter("columnName", null, null, null, false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(DateRange, false, null)))
+        );
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("A date range, value, and/or includeEmpty is required if column is not null", exception.getMessage());
+    }
+
+    @Test
+    void validateFailsWhenTooManyParametersAreProvided() {
+        var filter = new CustomExportFilter("columnName", LocalDate.parse("2025-01-01"), null, "value", false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(DateRange, false, null)))
+        );
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("A column can't be filtered both by date and value", exception.getMessage());
+    }
+
+    @Test
+    void validateFailsDateRangeIsProvidedToValueFiler() {
+        var filter = new CustomExportFilter("columnName", LocalDate.parse("2025-01-01"), null, null, false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(Value, false, null)))
+        );
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("columnName is not a date column", exception.getMessage());
+    }
+
+    @Test
+    void validateFailsForOutOfOrderDateRange() {
+        var filter = new CustomExportFilter(
+            "columnName",
+            LocalDate.parse("2025-01-01"),
+            LocalDate.parse("2024-12-31"),
+            null,
+            false
+        );
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(DateRange, false, null)))
+        );
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("dateFrom must be before dateTo", exception.getMessage());
+    }
+
+    public static Stream<Arguments> dateFiltersExamples() {
+        return Stream.of(
+            Arguments.of(
+                LocalDate.parse("2025-01-01"),
+                null,
+                "WHERE viewName.\"columnName\" >= '2025-01-01 00:00:00'"
+            ),
+            Arguments.of(
+                null,
+                LocalDate.parse("2025-01-01"),
+                "WHERE viewName.\"columnName\" <= '2025-01-01 23:59:59'"
+            ),
+            Arguments.of(
+                LocalDate.parse("2025-01-01"),
+                LocalDate.parse("2025-01-01"),
+                "WHERE viewName.\"columnName\" BETWEEN '2025-01-01 00:00:00' AND '2025-01-01 23:59:59'"
+            )
+        );
+    }
+
+    @ParameterizedTest(name = "{0} -> {1} = {2}")
+    @MethodSource("dateFiltersExamples")
+    void validateGeneratesDateRangeFilters(
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        String expectedFilter
+    ) throws CustomExportFilter.FilterValidationException {
+        var filter = new CustomExportFilter("columnName", dateFrom, dateTo, null, false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(DateRange, false, null)))
+        );
+
+        var validated = filter.validate(exportView);
+
+        assertEquals(expectedFilter, validated.whereClause());
+    }
+
+    @Test
+    void validateFailsForValueFiltersWithNoOptionsDefined() {
+        var filter = new CustomExportFilter("columnName", null, null, "value", false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(Value, false, null)))
+        );
+
+        // Config error - should be resolved by developer changing filter specification
+        assertThrows(
+            NullPointerException.class,
+            () -> filter.validate(exportView)
+        );
+    }
+
+    @Test
+    void validateFailsForValueFiltersOnDateColumn() {
+        var filter = new CustomExportFilter("columnName", null, null, "value", false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(DateRange, false, null)))
+        );
+
+       var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("columnName can not be filtered by value", exception.getMessage());
+    }
+
+    @Test
+    void validateFailsWhenInvalidValueIsProvided() {
+        var filter = new CustomExportFilter("columnName", null, null, "value", false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(Value, false, List.of("anotherValue"))))
+        );
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("value is not a valid value for columnName", exception.getMessage());
+    }
+
+    @Test
+    void validateGeneratesValueFilters() throws CustomExportFilter.FilterValidationException {
+        var filter = new CustomExportFilter("columnName", null, null, "value", false);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(Value, false, List.of("value"))))
+        );
+
+        var validated = filter.validate(exportView);
+
+        assertEquals("WHERE viewName.\"columnName\" = 'value'", validated.whereClause());
+    }
+
+    @Test
+    void validateFailsWhenIncludeEmptyProvidedToNonNullableColumn() {
+        var filter = new CustomExportFilter("columnName", null, null, null, true);
+        var exportView = exampleView(
+            List.of(new ExportField("columnName", null, new Filter(DateRange, false, null)))
+        );
+
+        var exception = assertThrows(
+            CustomExportFilter.FilterValidationException.class,
+            () -> filter.validate(exportView)
+        );
+
+        assertEquals("columnName can not be filtered to empty values", exception.getMessage());
+    }
+
+    public static Stream<Arguments> includeEmptyExamples() {
+        return Stream.of(
+            Arguments.of(
+                new CustomExportFilter("dateName", null, null, null, true),
+                "WHERE viewName.\"dateName\" IS NULL",
+                "Nullable date column is empty"
+            ),
+            Arguments.of(
+                new CustomExportFilter("dateName", LocalDate.parse("2025-01-01"), null, null, true),
+                "WHERE viewName.\"dateName\" >= '2025-01-01 00:00:00' OR viewName.\"dateName\" IS NULL",
+                "Nullable date column is in range or empty"
+            ),
+            Arguments.of(
+                new CustomExportFilter("valueName", null, null, null, true),
+                "WHERE viewName.\"valueName\" IS NULL",
+                "Nullable value column is empty"
+            ),
+            Arguments.of(
+                new CustomExportFilter("valueName", null, null, "value", true),
+                "WHERE viewName.\"valueName\" = 'value' OR viewName.\"valueName\" IS NULL",
+                "Nullable value column is a value or empty"
+            )
+        );
+    }
+
+    @ParameterizedTest(name = "{2}")
+    @MethodSource("includeEmptyExamples")
+    void validateGeneratesFiltersForNullableColumns(
+        CustomExportFilter filter,
+        String expectedFilter,
+        String label
+    ) throws CustomExportFilter.FilterValidationException {
+        var exportView = exampleView(
+            List.of(
+                new ExportField("dateName", null, new Filter(DateRange, true, null)),
+                new ExportField("valueName", null, new Filter(Value, true, List.of("value")))
+            )
+        );
+
+        var validated = filter.validate(exportView);
+
+        assertEquals(expectedFilter, validated.whereClause());
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/entrypoint/integration/BaseAwsSqsIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/entrypoint/integration/BaseAwsSqsIntegrationTest.java
@@ -1,24 +1,24 @@
 package uk.gov.digital.ho.hocs.audit.entrypoint.integration;
 
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.PurgeQueueRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
-import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
-import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 
-import java.util.concurrent.ExecutionException;
+import java.util.List;
 
 @SpringBootTest
 @ActiveProfiles({"local", "consumer"})
 public class BaseAwsSqsIntegrationTest {
 
+    private static final String APPROXIMATE_NUMBER_OF_MESSAGES = "ApproximateNumberOfMessages";
+
     @Autowired
-    protected SqsAsyncClient amazonSQSAsync;
+    protected AmazonSQSAsync amazonSQSAsync;
 
     @Value("${aws.sqs.audit.url}")
     protected String auditQueue;
@@ -28,32 +28,23 @@ public class BaseAwsSqsIntegrationTest {
 
     @BeforeEach
     public void setup() {
-        amazonSQSAsync.purgeQueue(PurgeQueueRequest.builder().queueUrl(auditQueue).build());
-        amazonSQSAsync.purgeQueue(PurgeQueueRequest.builder().queueUrl(auditQueueDlq).build());
+        amazonSQSAsync.purgeQueue(new PurgeQueueRequest(auditQueue));
+        amazonSQSAsync.purgeQueue(new PurgeQueueRequest(auditQueueDlq));
     }
 
     @AfterEach
     public void teardown() {
-        amazonSQSAsync.purgeQueue(PurgeQueueRequest.builder().queueUrl(auditQueue).build());
-        amazonSQSAsync.purgeQueue(PurgeQueueRequest.builder().queueUrl(auditQueueDlq).build());
+        amazonSQSAsync.purgeQueue(new PurgeQueueRequest(auditQueue));
+        amazonSQSAsync.purgeQueue(new PurgeQueueRequest(auditQueueDlq));
     }
 
-    public int getNumberOfMessagesOnQueue(String queue) throws ExecutionException, InterruptedException {
-        return getValueFromQueue(queue, QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES);
+    public int getNumberOfMessagesOnQueue(String queue) {
+        return getValueFromQueue(queue, APPROXIMATE_NUMBER_OF_MESSAGES);
     }
 
-    private int getValueFromQueue(
-        String queue,
-        QueueAttributeName attribute
-    ) throws ExecutionException, InterruptedException {
-        var queueAttributes = amazonSQSAsync.getQueueAttributes(
-            GetQueueAttributesRequest
-                .builder()
-                .queueUrl(queue)
-                .attributeNames(attribute)
-                .build()
-        );
-        var messageCount = queueAttributes.get().attributes().get(attribute);
+    private int getValueFromQueue(String queue, String attribute) {
+        var queueAttributes = amazonSQSAsync.getQueueAttributes(queue, List.of(attribute));
+        var messageCount = queueAttributes.getAttributes().get(attribute);
         return messageCount == null ? 0 : Integer.parseInt(messageCount);
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/audit/service/domain/converter/CorrespondentUuidToNameCacheTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/audit/service/domain/converter/CorrespondentUuidToNameCacheTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.digital.ho.hocs.audit.client.casework.CaseworkClient;
@@ -33,7 +32,6 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @ActiveProfiles({"local", "extracts"})
-@DirtiesContext
 public class CorrespondentUuidToNameCacheTest {
     @Mock
     CaseworkClient caseworkClient;


### PR DESCRIPTION
Firstly this reverts back to the dependency versions used for hocs-audit 3.3.0 that was the last know version that fully works in k8s environments.

[cs-prod-update-audit-materialized-views.yml](https://github.com/UKHomeOffice/hocs-audit/pull/545/files#diff-37dc6ec804c7af4fd0819bb5c6019a5d6e58f8eba39eee8da2d4ddaf5c0018ff) and [cs-qa-update-audit-materialized-views.yml](https://github.com/UKHomeOffice/hocs-audit/pull/545/files#diff-4433f5c7b06c2b045a2a621bcb95d3830aadc5ba9947fa47cec9114cde64a860) are for updating the DCU materialised views using a kubernetes job that were used to deploy [HOCS-7045](https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-7045) and will have future utility when it comes to add the extra indices added by [HOCS-7048](https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-7048)

The main work for [HOCS-7048](https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-7048) is in [CustomExportFilter.java](https://github.com/UKHomeOffice/hocs-audit/pull/545/files#diff-740dabc10cdf549d4082d22856935264804753accd36e6199ad8f7907ee121bc), tested by [CustomExportFilterTest.java](https://github.com/UKHomeOffice/hocs-audit/pull/545/files#diff-7359bebfc25fb9a791d9922688c4b237e931221b4cd6e314a19f3d864169d282). The rest is boilerplate updates to add the filter parameters to the endpoint, and use any where clause from the validated filter when reading the report data. Filters have been added to [custom-export-views.json](https://github.com/UKHomeOffice/hocs-audit/pull/545/files#diff-1dfaf88686f9fa7489998cdff4d5f3a88f83ba4c7d2fa7c8f9be317ea15be917) as required by the DCU analysts.