### PR TITLE
[HOCS-7048] Add caseType filter to dcu_business export

### DIFF
--- a/config/materializedviews/Audit-Schema-DataUpdates.sql
+++ b/config/materializedviews/Audit-Schema-DataUpdates.sql
@@ -248,6 +248,7 @@ CREATE INDEX idx_dcu_aggregated_cases_temp_case_completed ON DCU_AGGREGATED_CASE
 CREATE INDEX idx_dcu_aggregated_cases_temp_case_created ON DCU_AGGREGATED_CASES_TEMP("caseCreated");
 CREATE INDEX idx_dcu_aggregated_cases_temp_case_deadline ON DCU_AGGREGATED_CASES_TEMP("caseDeadline");
 CREATE INDEX idx_dcu_aggregated_cases_temp_case_status ON DCU_AGGREGATED_CASES_TEMP("caseStatus");
+CREATE INDEX idx_dcu_aggregated_cases_temp_case_type ON DCU_AGGREGATED_CASES_TEMP("caseType");
 CREATE INDEX idx_dcu_aggregated_cases_temp_last_modified ON DCU_AGGREGATED_CASES_TEMP("lastModified");
 CREATE INDEX idx_dcu_aggregated_cases_temp_latest_data_change ON DCU_AGGREGATED_CASES_TEMP("latestDataChange");
 
@@ -263,6 +264,7 @@ ALTER INDEX idx_dcu_aggregated_cases_temp_case_completed RENAME TO idx_dcu_aggre
 ALTER INDEX idx_dcu_aggregated_cases_temp_case_created RENAME TO idx_dcu_aggregated_cases_case_created;
 ALTER INDEX idx_dcu_aggregated_cases_temp_case_deadline RENAME TO idx_dcu_aggregated_cases_case_deadline;
 ALTER INDEX idx_dcu_aggregated_cases_temp_case_status RENAME TO idx_dcu_aggregated_cases_case_status;
+ALTER INDEX idx_dcu_aggregated_cases_temp_case_type RENAME TO idx_dcu_aggregated_cases_case_type;
 ALTER INDEX idx_dcu_aggregated_cases_temp_last_modified RENAME TO idx_dcu_aggregated_cases_last_modified;
 ALTER INDEX idx_dcu_aggregated_cases_temp_latest_data_change RENAME TO idx_dcu_aggregated_cases_latest_data_change;
 

--- a/config/materializedviews/cs-dev-update-audit-materialized-views.yml
+++ b/config/materializedviews/cs-dev-update-audit-materialized-views.yml
@@ -26,26 +26,26 @@ spec:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: cs-qa-audit-rds
+                  name: cs-dev-audit-rds
                   key: host
             - name: PGDATABASE
               valueFrom:
                 secretKeyRef:
-                  name: cs-qa-audit-rds
+                  name: cs-dev-audit-rds
                   key: name
             - name: DB_SCHEMA_NAME
               valueFrom:
                 secretKeyRef:
-                  name: cs-qa-audit-rds
+                  name: cs-dev-audit-rds
                   key: schema_name
             - name: PGUSER
               valueFrom:
                 secretKeyRef:
-                  name: cs-qa-audit-rds
+                  name: cs-dev-audit-rds
                   key: user_name
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: cs-qa-audit-rds
+                  name: cs-dev-audit-rds
                   key: password
       restartPolicy: Never

--- a/config/materializedviews/cs-prod-update-audit-materialized-views.yml
+++ b/config/materializedviews/cs-prod-update-audit-materialized-views.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: hocs-update-materialized-views
-          image: quay.io/ukhomeofficedigital/hocs-toolbox:1.7.1
+          image: quay.io/ukhomeofficedigital/hocs-toolbox:1.7.3
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/src/main/resources/config/custom-export-views.json
+++ b/src/main/resources/config/custom-export-views.json
@@ -216,7 +216,8 @@
         "filter": {"type": "Value", "options": ["Case Completed","In Progress", "NRN", "OGD"]}
       },
       {
-        "name": "caseType"
+        "name": "caseType",
+        "filter": {"type": "Value", "options": ["DTEN", "MIN", "TRO"]}
       },
       {
         "name": "caseUuid"


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-7048

> With regards to any additional filters (and if it's not too much trouble), I think having the ability to also filter by caseType, draftingTeam, and draftingUnit might be useful on for handling ad hoc requests for information.

draftingTeam, and draftingUnit will not be added at this time as these values would need to be queried via an API, and they are not guaranteed to be safe to use directly in an SQL query. 